### PR TITLE
Support Various File Types

### DIFF
--- a/ewms_pilot/__init__.py
+++ b/ewms_pilot/__init__.py
@@ -1,36 +1,9 @@
 """Init."""
 
-import logging
 
 from .pilot import consume_and_reply, main
 
-__all__ = ["consume_and_reply", "mq"]
-
-LOGGER = logging.getLogger("ewms-pilot")
-
-# find the installed MQClient package
-try:
-    import mqclient_nats  # type: ignore[import]
-
-    mq = mqclient_nats
-except ImportError:
-    try:
-        import mqclient_rabbitmq  # type: ignore[import]
-
-        mq = mqclient_rabbitmq
-    except ImportError:
-        try:
-            import mqclient_gcp  # type: ignore[import]
-
-            mq = mqclient_gcp
-        except ImportError:
-            try:
-                # Pulsar is the default, so try it last
-                import mqclient_pulsar  # type: ignore[import]
-
-                mq = mqclient_pulsar
-            except ImportError:
-                raise ImportError("No MQClient package installed.")
+__all__ = ["consume_and_reply"]
 
 # version is a human-readable version number.
 __version__ = "0.0.3"

--- a/ewms_pilot/mq.py
+++ b/ewms_pilot/mq.py
@@ -1,0 +1,25 @@
+"""Logic for getting the installed MWClient broker/backend API."""
+
+# find the installed MQClient package
+try:
+    import mqclient_nats  # type: ignore[import]
+
+    mq = mqclient_nats
+except ImportError:
+    try:
+        import mqclient_rabbitmq  # type: ignore[import]
+
+        mq = mqclient_rabbitmq
+    except ImportError:
+        try:
+            import mqclient_gcp  # type: ignore[import]
+
+            mq = mqclient_gcp
+        except ImportError:
+            try:
+                # Pulsar is the default, so try it last
+                import mqclient_pulsar  # type: ignore[import]
+
+                mq = mqclient_pulsar
+            except ImportError:
+                raise ImportError("No MQClient package installed.")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -4,6 +4,7 @@
 import argparse
 import asyncio
 import enum
+import json
 import pickle
 import subprocess
 import sys
@@ -16,16 +17,6 @@ from wipac_dev_tools import logging_tools
 
 from . import LOGGER, mq
 
-OUT_PKL = Path("out_msg.pkl")
-IN_PKL = Path("in_msg.pkl")
-
-
-# class DefaultPresumeExtension:
-#     """A stand-in for fancy file-extension determination logic."""
-
-
-# DEFAULT_PRESUME_EXTENSION = DefaultPresumeExtension()
-
 
 class FileEncoding(enum.Enum):
     """Various field extensions/encodings."""
@@ -36,109 +27,103 @@ class FileEncoding(enum.Enum):
     BINARY = "bin"
 
 
-class FileEncodingInterface:
-    def __init__(self, encoding: FileEncoding):
-        self.encoding = encoding
+class UniversalFileInterface:
+    """ """
 
-    def _get_fpath(self, fname_no_ext: str) -> Path:
-        return Path(f"./{fname_no_ext}.{self.encoding.value}")
+    def write(self, in_msg: Any, fpath: Path) -> None:
+        """Write `stuff` to `fpath` per `fpath.suffix`."""
+        self._write(in_msg, fpath)
+        LOGGER.info(f"File Written :: {fpath} ({fpath.stat().st_size} bytes)")
 
-    def write(self, stuff: Any, fname_no_ext: str = "in_msg") -> int:
-        """Write `stuff` to `file` per `self.encoding`.
-
-        By default, `fname_no_ext` is 'out.<ext>', where the `<ext>`
-        is the corresponding extension for `self.encoding`.
-        """
+    def _write(self, in_msg: Any, fpath: Path) -> None:
+        LOGGER.info(f"Writing payload to file @ {fpath}")
+        LOGGER.debug(in_msg)
 
         # PICKLE
-        if self.encoding == FileEncoding.PICKLE:
-            self._get_fpath(fname_no_ext)
-            pass
+        if fpath.suffix == FileEncoding.PICKLE.value:
+            with open(fpath, "wb") as f:
+                pickle.dump(in_msg, f)
         # PLAIN_TEXT
-        elif self.encoding == FileEncoding.PLAIN_TEXT:
-            self._get_fpath(fname_no_ext)
-            pass
+        elif fpath.suffix == FileEncoding.PLAIN_TEXT.value:
+            with open(fpath, "w") as f:
+                f.write(in_msg)
         # JSON
-        elif self.encoding == FileEncoding.JSON:
-            self._get_fpath(fname_no_ext)
-            pass
+        elif fpath.suffix == FileEncoding.JSON.value:
+            with open(fpath, "w") as f:
+                json.dump(in_msg, f)
         # BINARY
-        elif self.encoding == FileEncoding.BINARY:
-            self._get_fpath(fname_no_ext)
-            pass
-        # pass through...
-        raise ValueError(f"Unknown file encoding: {self.encoding}")
+        elif fpath.suffix == FileEncoding.BINARY.value:
+            with open(fpath, "wb") as f:
+                f.write(in_msg)
+        # ???
+        else:
+            raise ValueError(f"Unsupported file encoding: {fpath.suffix} ({fpath})")
 
-    def read(self, fname_no_ext: str = "out_msg") -> Any:
-        """Read and return contents of `file` per `self.encoding`.
+    def read_rm(self, fpath: Path) -> Any:
+        """Read and return contents of `fpath` per `fpath.suffix`, then rm the file."""
+        msg = self.read(fpath)
+        msg.unlink()
+        return msg
 
-        By default, `fname_no_ext` is 'in.<ext>', where the `<ext>`
-        is the corresponding extension for `self.encoding`.
-        """
+    def read(self, fpath: Path) -> Any:
+        """Read and return contents of `fpath` per `fpath.suffix`."""
+        msg = self._read(fpath)
+        LOGGER.info(f"File Read :: {fpath} ({fpath.stat().st_size} bytes)")
+        LOGGER.debug(msg)
+        return msg
+
+    def _read(self, fpath: Path) -> Any:
+        LOGGER.info(f"Reading payload from file @ {fpath}")
 
         # PICKLE
-        if self.encoding == FileEncoding.PICKLE:
-            self._get_fpath(fname_no_ext)
-            pass
+        if fpath.suffix == FileEncoding.PICKLE.value:
+            with open(fpath, "rb") as f:
+                return pickle.load(f)
         # PLAIN_TEXT
-        elif self.encoding == FileEncoding.PLAIN_TEXT:
-            self._get_fpath(fname_no_ext)
-            pass
+        elif fpath.suffix == FileEncoding.PLAIN_TEXT.value:
+            with open(fpath, "r") as f:
+                return f.read()
         # JSON
-        elif self.encoding == FileEncoding.JSON:
-            self._get_fpath(fname_no_ext)
-            pass
+        elif fpath.suffix == FileEncoding.JSON.value:
+            with open(fpath, "r") as f:
+                return json.load(f)
         # BINARY
-        elif self.encoding == FileEncoding.BINARY:
-            self._get_fpath(fname_no_ext)
-            pass
-        # pass through...
-        raise ValueError(f"Unknown file encoding: {self.encoding}")
+        elif fpath.suffix == FileEncoding.BINARY.value:
+            with open(fpath, "wb") as f:
+                return f.read()
+        # ???
+        else:
+            raise ValueError(f"Unsupported file encoding: {fpath.suffix} ({fpath})")
 
 
-def inmsg_to_infile(in_msg: Any, debug_infile: Optional[Path]) -> Path:
+def inmsg_to_infile(
+    in_msg_path: Path, in_msg: Any, debug_infile: Optional[Path]
+) -> Path:
     """Write the msg to the `IN` file.
 
     Also, dump to a file for debugging (if not "").
     """
-    with open(IN_PKL, "wb") as f:
-        LOGGER.info(f"Pickle-dumping in-payload to file: {str(in_msg)} @ {IN_PKL}")
-        pickle.dump(in_msg, f)
-    LOGGER.info(f"Pickle File:: {IN_PKL} ({IN_PKL.stat().st_size} bytes)")
+    UniversalFileInterface().write(in_msg, in_msg_path)
 
     if debug_infile:  # for debugging
-        with open(debug_infile, "wb") as f:
-            LOGGER.info(
-                f"Pickle-dumping in-payload to file: {str(in_msg)} @ {debug_infile}"
-            )
-            pickle.dump(in_msg, f)
-        LOGGER.info(
-            f"Pickle File:: {debug_infile} ({debug_infile.stat().st_size} bytes)"
-        )
+        UniversalFileInterface().write(in_msg, debug_infile)
 
-    return IN_PKL
+    return in_msg_path
 
 
-def outfile_to_outmsg(debug_outfile: Optional[Path]) -> Any:
+def outfile_to_outmsg(out_msg_path: Path, debug_outfile: Optional[Path]) -> Any:
     """Read the msg from the `OUT` file.
 
     Also, dump to a file for debugging (if not "").
     """
-    with open(OUT_PKL, "rb") as f:
-        out_msg = pickle.load(f)
-        LOGGER.info(f"Pickle-loaded out-payload from file: {str(out_msg)} @ {OUT_PKL}")
-    LOGGER.info(f"Pickle File:: {OUT_PKL} ({OUT_PKL.stat().st_size} bytes)")
-    OUT_PKL.unlink()  # rm
+    if not out_msg_path.exists():
+        LOGGER.error("Out file was not written for in-payload")
+        raise RuntimeError("Out file was not written for in-payload")
+
+    out_msg = UniversalFileInterface().read_rm(out_msg_path)
 
     if debug_outfile:  # for debugging
-        with open(debug_outfile, "wb") as f:
-            LOGGER.info(
-                f"Pickle-dumping out-payload to file: {str(out_msg)} @ {debug_outfile}"
-            )
-            pickle.dump(out_msg, f)
-        LOGGER.info(
-            f"Pickle File:: {debug_outfile} ({debug_outfile.stat().st_size} bytes)"
-        )
+        UniversalFileInterface().write(out_msg, debug_outfile)
 
     return out_msg
 
@@ -151,7 +136,8 @@ async def consume_and_reply(
     queue_from_clients: str,  # for mq
     timeout_to_clients: int,  # for mq
     timeout_from_clients: int,  # for mq
-    debug_directory: Optional[Path] = None,
+    file_encoding: FileEncoding = FileEncoding.PICKLE,
+    debug_dir: Optional[Path] = None,
 ) -> None:
     """Communicate with server and outsource processing to subprocesses."""
     LOGGER.info("Making MQClient queue connections...")
@@ -178,13 +164,15 @@ async def consume_and_reply(
 
             # debugging logic
             debug_infile, debug_outfile = None, None
-            if debug_directory:
+            if debug_dir:
                 debug_time = time.time()
-                debug_infile = debug_directory / f"{debug_time}.in.pkl"
-                debug_outfile = debug_directory / f"{debug_time}.out.pkl"
+                debug_infile = debug_dir / f"{debug_time}.in.{file_encoding.value}"
+                debug_outfile = debug_dir / f"{debug_time}.out.{file_encoding.value}"
 
             # write
-            inmsg_to_infile(in_msg, debug_infile)
+            inmsg_to_infile(
+                Path(f"./in_msg.{file_encoding.value}"), in_msg, debug_infile
+            )
 
             # call & check outputs
             LOGGER.info(f"Executing: {cmd.split()}")
@@ -198,12 +186,11 @@ async def consume_and_reply(
             print(result.stderr, file=sys.stderr)
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, cmd.split())
-            if not OUT_PKL.exists():
-                LOGGER.error("Out file was not written for in-payload")
-                raise RuntimeError("Out file was not written for in-payload")
 
             # get
-            out_msg = outfile_to_outmsg(debug_outfile)
+            out_msg = outfile_to_outmsg(
+                Path(f"./out_msg.{file_encoding.value}"), debug_outfile
+            )
 
             # send
             LOGGER.info("Sending out-payload to server...")
@@ -318,7 +305,8 @@ def main() -> None:
             queue_from_clients=f"from-clients-{args.mq_basename}",
             timeout_to_clients=args.timeout_to_clients,
             timeout_from_clients=args.timeout_from_clients,
-            debug_directory=args.debug_directory,
+            file_encoding=FileEncoding(args.encoding),
+            debug_dir=args.debug_directory,
         )
     )
     LOGGER.info("Done.")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import enum
 import json
+import logging
 import pickle
 import subprocess
 import sys
@@ -15,7 +16,9 @@ from typing import Any, Callable, Optional
 import asyncstdlib as asl
 from wipac_dev_tools import logging_tools
 
-from . import LOGGER, mq
+from .mq import mq
+
+LOGGER = logging.getLogger("ewms-pilot")
 
 
 class FileEncoding(enum.Enum):

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -124,7 +124,7 @@ def read_from_client(
 
     # persist the file?
     if debug_subdir:
-        fpath_from_client.rename(debug_subdir)  # mv
+        fpath_from_client.rename(debug_subdir / fpath_from_client.name)  # mv
     else:
         fpath_from_client.unlink()  # rm
 

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -242,11 +242,18 @@ def main() -> None:
         help="the command to give the subprocess script",
     )
     parser.add_argument(
-        "-e",
-        "--encoding",
-        default=FileEncoding.PICKLE.value,
-        choices=[e.value for e in FileEncoding],
-        help="which file encoding to use for in- & out-files",
+        "--in",
+        dest="infile",
+        default=Path("./in.pkl"),
+        type=Path,
+        help="which file to write for the client subprocess",
+    )
+    parser.add_argument(
+        "--out",
+        dest="outfile",
+        default=Path("./out.pkl"),
+        type=Path,
+        help="which file to read from the client subprocess",
     )
 
     # mq args
@@ -322,8 +329,8 @@ def main() -> None:
             queue_from_clients=f"from-clients-{args.mq_basename}",
             timeout_to_clients=args.timeout_to_clients,
             timeout_from_clients=args.timeout_from_clients,
-            fpath_to_client=Path(f"./in.{args.encoding}"),
-            fpath_from_client=Path(f"./out.{args.encoding}"),
+            fpath_to_client=args.infile,
+            fpath_from_client=args.outfile,
             debug_dir=args.debug_directory,
             # file_writer=UniversalFileInterface.write,
             # file_reader=UniversalFileInterface.read,

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -11,10 +11,10 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional
 
 import asyncstdlib as asl
-from wipac_dev_tools import logging_tools
+from wipac_dev_tools import argparse_tools, logging_tools
 
 from .mq import mq
 
@@ -224,21 +224,6 @@ async def consume_and_reply(
 def main() -> None:
     """Start up EWMS Pilot subprocess to perform an MQ task."""
 
-    def _create_dir(val: str) -> Optional[Path]:
-        if not val:
-            return None
-        path = Path(val)
-        path.mkdir(parents=True, exist_ok=True)
-        return path
-
-    T = TypeVar("T")
-
-    def _validate_arg(val: T, test: bool, exc: Exception) -> T:
-        """Validation `val` by checking `test` and raise `exc` if that is falsy."""
-        if test:
-            return val
-        raise exc
-
     parser = argparse.ArgumentParser(
         description="Start up EWMS Pilot subprocess to perform an MQ task",
         epilog="",
@@ -253,7 +238,7 @@ def main() -> None:
         "--in",
         dest="infile",
         default=Path("./in.pkl"),
-        type=lambda x: _validate_arg(
+        type=lambda x: argparse_tools.validate_arg(
             Path(x),
             Path(x).suffix in [e.value for e in FileType],
             argparse.ArgumentTypeError(f"Unsupported file type: {x}"),
@@ -264,7 +249,7 @@ def main() -> None:
         "--out",
         dest="outfile",
         default=Path("./out.pkl"),
-        type=lambda x: _validate_arg(
+        type=lambda x: argparse_tools.validate_arg(
             Path(x),
             Path(x).suffix in [e.value for e in FileType],
             argparse.ArgumentTypeError(f"Unsupported file type: {x}"),
@@ -320,7 +305,7 @@ def main() -> None:
     parser.add_argument(
         "--debug-directory",
         default="",
-        type=_create_dir,
+        type=argparse_tools.create_dir,
         help="a directory to write all the incoming/outgoing .pkl files "
         "(useful for debugging)",
     )

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import enum
 import pickle
 import subprocess
 import sys
@@ -17,6 +18,82 @@ from . import LOGGER, mq
 
 OUT_PKL = Path("out_msg.pkl")
 IN_PKL = Path("in_msg.pkl")
+
+
+# class DefaultPresumeExtension:
+#     """A stand-in for fancy file-extension determination logic."""
+
+
+# DEFAULT_PRESUME_EXTENSION = DefaultPresumeExtension()
+
+
+class FileEncoding(enum.Enum):
+    """Various field extensions/encodings."""
+
+    PICKLE = "pkl"
+    PLAIN_TEXT = "txt"
+    JSON = "json"
+    BINARY = "bin"
+
+
+class FileEncodingInterface:
+    def __init__(self, encoding: FileEncoding):
+        self.encoding = encoding
+
+    def _get_fpath(self, fname_no_ext: str) -> Path:
+        return Path(f"./{fname_no_ext}.{self.encoding.value}")
+
+    def write(self, stuff: Any, fname_no_ext: str = "in_msg") -> int:
+        """Write `stuff` to `file` per `self.encoding`.
+
+        By default, `fname_no_ext` is 'out.<ext>', where the `<ext>`
+        is the corresponding extension for `self.encoding`.
+        """
+
+        # PICKLE
+        if self.encoding == FileEncoding.PICKLE:
+            self._get_fpath(fname_no_ext)
+            pass
+        # PLAIN_TEXT
+        elif self.encoding == FileEncoding.PLAIN_TEXT:
+            self._get_fpath(fname_no_ext)
+            pass
+        # JSON
+        elif self.encoding == FileEncoding.JSON:
+            self._get_fpath(fname_no_ext)
+            pass
+        # BINARY
+        elif self.encoding == FileEncoding.BINARY:
+            self._get_fpath(fname_no_ext)
+            pass
+        # pass through...
+        raise ValueError(f"Unknown file encoding: {self.encoding}")
+
+    def read(self, fname_no_ext: str = "out_msg") -> Any:
+        """Read and return contents of `file` per `self.encoding`.
+
+        By default, `fname_no_ext` is 'in.<ext>', where the `<ext>`
+        is the corresponding extension for `self.encoding`.
+        """
+
+        # PICKLE
+        if self.encoding == FileEncoding.PICKLE:
+            self._get_fpath(fname_no_ext)
+            pass
+        # PLAIN_TEXT
+        elif self.encoding == FileEncoding.PLAIN_TEXT:
+            self._get_fpath(fname_no_ext)
+            pass
+        # JSON
+        elif self.encoding == FileEncoding.JSON:
+            self._get_fpath(fname_no_ext)
+            pass
+        # BINARY
+        elif self.encoding == FileEncoding.BINARY:
+            self._get_fpath(fname_no_ext)
+            pass
+        # pass through...
+        raise ValueError(f"Unknown file encoding: {self.encoding}")
 
 
 def inmsg_to_infile(in_msg: Any, debug_infile: Optional[Path]) -> Path:

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -27,7 +27,6 @@ class FileType(enum.Enum):
     PICKLE = "pkl"
     PLAIN_TEXT = "txt"
     JSON = "json"
-    BINARY = "bin"
 
 
 class UniversalFileInterface:
@@ -56,10 +55,6 @@ class UniversalFileInterface:
         elif fpath.suffix == FileType.JSON.value:
             with open(fpath, "w") as f:
                 json.dump(in_msg, f)
-        # BINARY
-        elif fpath.suffix == FileType.BINARY.value:
-            with open(fpath, "wb") as f:
-                f.write(in_msg)
         # ???
         else:
             raise ValueError(f"Unsupported file type: {fpath.suffix} ({fpath})")
@@ -88,10 +83,6 @@ class UniversalFileInterface:
         elif fpath.suffix == FileType.JSON.value:
             with open(fpath, "r") as f:
                 return json.load(f)
-        # BINARY
-        elif fpath.suffix == FileType.BINARY.value:
-            with open(fpath, "wb") as f:
-                return f.read()
         # ???
         else:
             raise ValueError(f"Unsupported file type: {fpath.suffix} ({fpath})")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -160,6 +160,13 @@ def main() -> None:
         required=True,
         help="the command to give the subprocess script",
     )
+    parser.add_argument(
+        "-e",
+        "--encoding",
+        default=FileEncoding.PICKLE.value,
+        choices=[e.value for e in FileEncoding],
+        help="which file encoding to use for in- & out-files",
+    )
 
     # mq args
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.4.0
+wipac-dev-tools==1.5.0
     # via wipac-mqclient-pulsar
 wipac-mqclient==0.5.1
     # via wipac-mqclient-pulsar


### PR DESCRIPTION
Out-of-the-box, we support pickle (default), json, ~bin,~ and txt (plain text). These are available from the CL.

If used as an API module, the user can also pass in functions (as arguments) for reading/writing the in/out files.

closes #3 