### PR TITLE
Pathlib `rename()` Workaround

### DIFF
--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -8,6 +8,7 @@ import json
 import logging
 import pickle
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -125,7 +126,8 @@ def read_from_subproc(
 
     # persist the file?
     if debug_subdir:
-        fpath_from_subproc.rename(debug_subdir / fpath_from_subproc.name)  # mv
+        # fpath_from_subproc.rename(debug_subdir / fpath_from_subproc.name)  # mv
+        shutil.move(fpath_from_subproc, debug_subdir / fpath_from_subproc.name)
     else:
         fpath_from_subproc.unlink()  # rm
 

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -127,6 +127,7 @@ def read_from_subproc(
     # persist the file?
     if debug_subdir:
         # fpath_from_subproc.rename(debug_subdir / fpath_from_subproc.name)  # mv
+        # NOTE: https://github.com/python/cpython/pull/30650
         shutil.move(fpath_from_subproc, debug_subdir / fpath_from_subproc.name)
     else:
         fpath_from_subproc.unlink()  # rm

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -46,7 +46,7 @@ grpcio-status==1.49.1
     #   google-cloud-pubsub
 idna==3.4
     # via requests
-nats-py[nkeys]==2.1.7
+nats-py[nkeys]==2.2.0
     # via wipac-mqclient
 nkeys==0.1.0
     # via nats-py
@@ -84,7 +84,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[all,pulsar]==0.6.1
+wipac-mqclient[all,pulsar]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -76,7 +76,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[gcp,pulsar]==0.6.1
+wipac-mqclient[gcp,pulsar]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -16,7 +16,7 @@ ed25519==1.5
     # via nkeys
 idna==3.4
     # via requests
-nats-py[nkeys]==2.1.7
+nats-py[nkeys]==2.2.0
     # via wipac-mqclient
 nkeys==0.1.0
     # via nats-py
@@ -30,7 +30,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[nats,pulsar]==0.6.1
+wipac-mqclient[nats,pulsar]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -24,7 +24,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[pulsar]==0.6.1
+wipac-mqclient[pulsar]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -26,7 +26,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[pulsar,rabbitmq]==0.6.1
+wipac-mqclient[pulsar,rabbitmq]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -44,7 +44,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[pulsar]==0.6.1
+wipac-mqclient[pulsar]==0.6.2
     # via ewms-pilot (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ typing-extensions==4.3.0
     # via wipac-dev-tools
 urllib3==1.26.12
     # via requests
-wipac-dev-tools==1.5.1
+wipac-dev-tools==1.5.5
     # via wipac-mqclient
-wipac-mqclient[pulsar]==0.6.1
+wipac-mqclient[pulsar]==0.6.2
     # via ewms-pilot (setup.py)


### PR DESCRIPTION
In a docker container, we get `OSError: [Errno 18] Invalid cross-device link` when using `pathlib`'s `rename()`. This is documented here: https://github.com/python/cpython/pull/30650