### PR TITLE
Add `EWMS_PILOT_HTCHIRP`

### DIFF
--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -30,6 +30,9 @@ class EnvConfig:
     EWMS_PILOT_LOG: str = "INFO"
     EWMS_PILOT_LOG_THIRD_PARTY: str = "WARNING"
 
+    # chirp
+    EWMS_PILOT_HTCHIRP: bool = False
+
     # meta
     EWMS_PILOT_TASK_TIMEOUT: Optional[int] = None
     EWMS_PILOT_QUARANTINE_TIME: int = 0  # seconds

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -22,15 +22,15 @@ nkeys==0.1.0
     # via nats-py
 oms-mqclient[all]==2.1.0
     # via ewms-pilot (setup.py)
-pika==1.3.1
+pika==1.3.2
     # via oms-mqclient
 pulsar-client==3.1.0
     # via oms-mqclient
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -20,11 +20,11 @@ nkeys==0.1.0
     # via nats-py
 oms-mqclient[nats]==2.1.0
     # via ewms-pilot (setup.py)
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -18,11 +18,11 @@ oms-mqclient[pulsar]==2.1.0
     # via ewms-pilot (setup.py)
 pulsar-client==3.1.0
     # via oms-mqclient
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -14,13 +14,13 @@ idna==3.4
     # via requests
 oms-mqclient[rabbitmq]==2.1.0
     # via ewms-pilot (setup.py)
-pika==1.3.1
+pika==1.3.2
     # via oms-mqclient
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -35,13 +35,13 @@ pytest-asyncio==0.21.0
     # via ewms-pilot (setup.py)
 pytest-xdist==3.2.1
     # via ewms-pilot (setup.py)
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 tomli==2.0.1
     # via pytest
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ idna==3.4
     # via requests
 oms-mqclient==2.1.0
     # via ewms-pilot (setup.py)
-requests==2.29.0
+requests==2.30.0
     # via wipac-dev-tools
 typing-extensions==4.5.0
     # via wipac-dev-tools
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
 wipac-dev-tools==1.6.15
     # via oms-mqclient


### PR DESCRIPTION
Adds an opt-in style environment variable: `EWMS_PILOT_HTCHIRP`. Not all pilots ran on a condor node want to use chirp.

The submit classad must indicate `+WantIOProxy = true`, so this is not a new pattern (opt-in).