### PR TITLE
Use `1` if `EWMS_PILOT_CONCURRENT_TASKS < 1`

### DIFF
--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -51,5 +51,12 @@ class EnvConfig:
                 # b/c frozen
                 object.__setattr__(self, "EWMS_PILOT_TASK_TIMEOUT", int(timeout))
 
+        if self.EWMS_PILOT_CONCURRENT_TASKS < 1:
+            LOGGER.warning(
+                f"Invalid value for 'EWMS_PILOT_CONCURRENT_TASKS' ({self.EWMS_PILOT_CONCURRENT_TASKS}),"
+                " defaulting to '1'."
+            )
+            object.__setattr__(self, "EWMS_PILOT_CONCURRENT_TASKS", 1)  # b/c frozen
+
 
 ENV = from_environment_as_dataclass(EnvConfig)

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -16,7 +16,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-nats-py[nkeys]==2.2.0
+nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
@@ -24,13 +24,13 @@ oms-mqclient[all]==2.1.0
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient
-pulsar-client==3.1.0
+pulsar-client==3.2.0
     # via oms-mqclient
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/requirements-nats.txt
+++ b/requirements-nats.txt
@@ -14,17 +14,17 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-nats-py[nkeys]==2.2.0
+nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
 oms-mqclient[nats]==2.1.0
     # via ewms-pilot (setup.py)
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/requirements-pulsar.txt
+++ b/requirements-pulsar.txt
@@ -16,13 +16,13 @@ idna==3.4
     # via requests
 oms-mqclient[pulsar]==2.1.0
     # via ewms-pilot (setup.py)
-pulsar-client==3.1.0
+pulsar-client==3.2.0
     # via oms-mqclient
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/requirements-rabbitmq.txt
+++ b/requirements-rabbitmq.txt
@@ -16,11 +16,11 @@ oms-mqclient[rabbitmq]==2.1.0
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=test --output-file=requirements-test.txt
 #
-asyncstdlib==3.10.7
+asyncstdlib==3.10.8
     # via ewms-pilot (setup.py)
 certifi==2023.5.7
     # via requests
@@ -33,15 +33,15 @@ pytest==7.3.1
     #   pytest-xdist
 pytest-asyncio==0.21.0
     # via ewms-pilot (setup.py)
-pytest-xdist==3.2.1
+pytest-xdist==3.3.1
     # via ewms-pilot (setup.py)
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
 tomli==2.0.1
     # via pytest
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ idna==3.4
     # via requests
 oms-mqclient==2.1.0
     # via ewms-pilot (setup.py)
-requests==2.30.0
+requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via oms-mqclient


### PR DESCRIPTION
Previously (currently), a value of `0` causes problems further downstream. Semantically, using `0` could also be interpreted as not wanting to enable multitasking -- which is effectively the same as a value of `1`.