### PR TITLE
Heartbeat Fix for Long Asynchronous Tasks

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -2,10 +2,6 @@ name: wipac ci/cd
 
 on: [push]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # don't cancel on main/master/default
-  cancel-in-progress: ${{ format('refs/heads/{0}', github.event.repository.default_branch) != github.ref }}
 
 env:
   PULSAR_CONTAINER: pulsar_local

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -66,7 +66,7 @@ jobs:
           github.ref_type == 'branch' &&
           format('refs/heads/{0}', github.event.repository.default_branch) != github.ref
         name: wipac-dev-py-setup-action (only for non-dependabot non-default branches)
-        uses: WIPACrepo/wipac-dev-py-setup-action@v2.2
+        uses: WIPACrepo/wipac-dev-py-setup-action@v2.5
         with:
           base-keywords: WIPAC IceCube "Observation Management Service" "Event Workflow Managment Service"
 

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -28,7 +28,7 @@ pulsar-client==3.1.0
     # via oms-mqclient
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -30,7 +30,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -20,7 +20,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.3
+oms-mqclient[all]==2.4.4
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -20,7 +20,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.4
+oms-mqclient[all]==2.4.5
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -16,7 +16,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-nats-py[nkeys]==2.3.1
+nats-py[nkeys]==2.4.0
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -20,7 +20,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.5
+oms-mqclient[all]==2.4.6
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-nats-py[nkeys]==2.3.1
+nats-py[nkeys]==2.4.0
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -49,7 +49,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -26,7 +26,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.4
+oms-mqclient[all]==2.4.5
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -26,7 +26,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.5
+oms-mqclient[all]==2.4.6
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -26,17 +26,17 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[all]==2.4.3
+oms-mqclient[all]==2.4.4
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest
 pika==1.3.2
     # via oms-mqclient
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 pulsar-client==3.1.0
     # via oms-mqclient
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   ewms-pilot (setup.py)
     #   pytest-asyncio

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -47,7 +47,7 @@ pytest-xdist==3.3.1
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -14,7 +14,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-nats-py[nkeys]==2.3.1
+nats-py[nkeys]==2.4.0
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -18,7 +18,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[nats]==2.4.3
+oms-mqclient[nats]==2.4.4
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -24,7 +24,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -18,7 +18,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[nats]==2.4.4
+oms-mqclient[nats]==2.4.5
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -18,7 +18,7 @@ nats-py[nkeys]==2.3.1
     # via oms-mqclient
 nkeys==0.1.0
     # via nats-py
-oms-mqclient[nats]==2.4.5
+oms-mqclient[nats]==2.4.6
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -22,7 +22,7 @@ oms-mqclient[nats]==2.4.6
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -20,7 +20,7 @@ pulsar-client==3.1.0
     # via oms-mqclient
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -14,7 +14,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[pulsar]==2.4.5
+oms-mqclient[pulsar]==2.4.6
     # via ewms-pilot (setup.py)
 pulsar-client==3.1.0
     # via oms-mqclient

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -14,7 +14,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[pulsar]==2.4.3
+oms-mqclient[pulsar]==2.4.4
     # via ewms-pilot (setup.py)
 pulsar-client==3.1.0
     # via oms-mqclient

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -14,7 +14,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[pulsar]==2.4.4
+oms-mqclient[pulsar]==2.4.5
     # via ewms-pilot (setup.py)
 pulsar-client==3.1.0
     # via oms-mqclient

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -22,7 +22,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -20,7 +20,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[rabbitmq]==2.4.3
+oms-mqclient[rabbitmq]==2.4.4
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[rabbitmq]==2.4.5
+oms-mqclient[rabbitmq]==2.4.6
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -18,7 +18,7 @@ pika==1.3.2
     # via oms-mqclient
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient[rabbitmq]==2.4.4
+oms-mqclient[rabbitmq]==2.4.5
     # via ewms-pilot (setup.py)
 pika==1.3.2
     # via oms-mqclient

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -18,13 +18,13 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-oms-mqclient==2.4.3
+oms-mqclient==2.4.4
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   ewms-pilot (setup.py)
     #   pytest-asyncio

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -18,7 +18,7 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-oms-mqclient==2.4.4
+oms-mqclient==2.4.5
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -35,7 +35,7 @@ pytest-xdist==3.3.1
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -37,7 +37,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -18,7 +18,7 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-oms-mqclient==2.4.5
+oms-mqclient==2.4.6
     # via ewms-pilot (setup.py)
 packaging==23.1
     # via pytest

--- a/dependencies.log
+++ b/dependencies.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient==2.4.4
+oms-mqclient==2.4.5
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies.log
+++ b/dependencies.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient==2.4.5
+oms-mqclient==2.4.6
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies.log
+++ b/dependencies.log
@@ -12,7 +12,7 @@ htchirp==2.0
     # via ewms-pilot (setup.py)
 idna==3.4
     # via requests
-oms-mqclient==2.4.3
+oms-mqclient==2.4.4
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools

--- a/dependencies.log
+++ b/dependencies.log
@@ -16,7 +16,7 @@ oms-mqclient==2.4.6
     # via ewms-pilot (setup.py)
 requests==2.31.0
     # via wipac-dev-tools
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via wipac-dev-tools
 urllib3==2.0.4
     # via requests

--- a/dependencies.log
+++ b/dependencies.log
@@ -18,7 +18,7 @@ requests==2.31.0
     # via wipac-dev-tools
 typing-extensions==4.8.0
     # via wipac-dev-tools
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 wipac-dev-tools==1.6.16
     # via oms-mqclient

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -465,6 +465,10 @@ async def _consume_and_reply(
                 total_msg_count += 1
                 LOGGER.info(f"Got a task to process (#{total_msg_count}): {in_msg}")
 
+                # after the first message, set the timeout to the "normal" amount
+                if in_queue.timeout != timeout_incoming:
+                    in_queue.timeout = timeout_incoming
+
                 if total_msg_count == 1:
                     utils.chirp_status("Tasking")
 
@@ -495,9 +499,6 @@ async def _consume_and_reply(
                         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
                         _send_heartbeat_to_rabbitmq=_send_heartbeat_to_rabbitmq,
                     )
-                    # after the first set of messages, set the timeout to the "normal" amount
-                    if in_queue.timeout != timeout_incoming:
-                        in_queue.timeout = timeout_incoming
 
                 # if 1+ fail, then don't consume anymore; wait for remaining tasks
                 if task_errors:

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -38,7 +38,7 @@ _EXCEPT_ERRORS = False
 _DEFAULT_TIMEOUT_INCOMING = 1  # second
 _DEFAULT_TIMEOUT_OUTGOING = 1  # second
 
-_HOUSEKEEPING_TIMEOUT = 5.0  # second
+_HOUSEKEEPING_TIMEOUT: int = 5  # second
 
 
 class FileType(enum.Enum):
@@ -324,6 +324,7 @@ async def _wait_on_tasks_with_ack(
     tasks_msgs: AsyncioTaskMessages,
     # return_when_all_done: bool,
     previous_task_errors: List[BaseException],
+    timeout: int,
 ) -> Tuple[AsyncioTaskMessages, List[BaseException]]:
     """Get finished tasks and ack/nack their messages.
 
@@ -354,7 +355,7 @@ async def _wait_on_tasks_with_ack(
     done, pending = await asyncio.wait(
         pending,
         return_when=asyncio.FIRST_COMPLETED,
-        timeout=_HOUSEKEEPING_TIMEOUT,
+        timeout=timeout,
     )
 
     # HANDLE FINISHED TASK(S)
@@ -475,7 +476,7 @@ async def _consume_and_reply(
         # "listener loop" -- get messages and do tasks
         # intermittently halt listening to process housekeeping things
         #
-        in_queue.timeout = int(_HOUSEKEEPING_TIMEOUT)
+        in_queue.timeout = _HOUSEKEEPING_TIMEOUT
         listener_loop_timeout = timeout_wait_for_first_message or timeout_incoming
         recent_msg_ts = time.time()
         while not listener_loop_exit(task_errors, recent_msg_ts, listener_loop_timeout):
@@ -523,6 +524,7 @@ async def _consume_and_reply(
                 # return_when_all_done=False,
                 previous_task_errors=task_errors,
                 # housekeeping_fn=housekeeping_fn,
+                timeout=_HOUSEKEEPING_TIMEOUT,
             )
 
         #
@@ -540,6 +542,7 @@ async def _consume_and_reply(
                 # return_when_all_done=False,
                 previous_task_errors=task_errors,
                 # housekeeping_fn=housekeeping_fn,
+                timeout=_HOUSEKEEPING_TIMEOUT,
             )
 
     # log/chirp

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -28,7 +28,7 @@ _EXCEPT_ERRORS = False
 _DEFAULT_TIMEOUT_INCOMING = 1  # second
 _DEFAULT_TIMEOUT_OUTGOING = 1  # second
 
-_HOUSEKEEPING_TIMEOUT = 1.0  # second
+_HOUSEKEEPING_TIMEOUT = 5.0  # second
 
 
 class FileType(enum.Enum):

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -471,7 +471,7 @@ async def _consume_and_reply(
         in_queue.timeout = int(_HOUSEKEEPING_TIMEOUT)
         timeout = timeout_wait_for_first_message or timeout_incoming
         time_of_last_message = time.time()
-        while (not task_errors) and did_timeout(time_of_last_message, timeout):
+        while (not task_errors) and (not did_timeout(time_of_last_message, timeout)):
             housekeeping_fn()
             #
             # get messages/tasks

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -334,6 +334,8 @@ async def _wait_on_tasks_with_ack(
             List[BaseException]: failed tasks' exceptions (plus those in `previous_task_errors`)
     """
     pending: Set[asyncio.Task] = set(tasks_msgs.keys())  # type: ignore[type-arg]
+    if not pending:
+        return {}, previous_task_errors
 
     async def handle_failed_task(task: asyncio.Task, exception: BaseException) -> None:  # type: ignore[type-arg]
         previous_task_errors.append(exception)

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -434,6 +434,8 @@ class Housekeeping:
         pub: mq.queue.QueuePubResource,
     ) -> None:
         """Do housekeeping."""
+        await asyncio.sleep(0)  # hand over control to other async tasks
+
         # rabbitmq heartbeats
         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
         if in_queue._broker_client.NAME.lower() == "rabbitmq":
@@ -447,8 +449,7 @@ class Housekeeping:
                         LOGGER.info("sending heartbeat to RabbitMQ broker...")
                         raw_q.connection.process_data_events()  # type: ignore[attr-defined, union-attr]
 
-        # other housekeeping
-        await asyncio.sleep(0)  # hand over control to other async tasks
+        # TODO -- add other housekeeping
 
 
 async def _consume_and_reply(

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -443,9 +443,9 @@ class Housekeeping:
             ):
                 self.prev_rabbitmq_heartbeat = time.time()
                 for raw_q in [pub.pub, sub._sub]:
-                    if raw_q.connection:  # type: ignore[union-attr]
+                    if raw_q.connection:  # type: ignore[attr-defined, union-attr]
                         LOGGER.info("sending heartbeat to RabbitMQ broker...")
-                        raw_q.connection.process_data_events()  # type: ignore[union-attr]
+                        raw_q.connection.process_data_events()  # type: ignore[attr-defined, union-attr]
 
         # TODO -- add other housekeeping
 

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -518,6 +518,7 @@ async def _consume_and_reply(
             task_errors, msg_waittime_current, msg_waittime_timeout
         ):
             housekeeper.work(in_queue, sub, pub)
+            await asyncio.sleep(0)  # hand over control to other async tasks
             #
             # get messages/tasks
             if len(pending) >= multitasking:

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -8,6 +8,7 @@ import json
 import pickle
 import shlex
 import shutil
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -19,6 +20,14 @@ from wipac_dev_tools import argparse_tools, logging_tools
 
 from . import utils
 from .config import ENV, LOGGER
+
+# fmt:off
+if sys.version_info[1] < 10:
+    # this is built in for py3.10+
+    async def anext(ait):
+        return await ait.__anext__()
+# fmt:on
+
 
 AsyncioTaskMessages = Dict[asyncio.Task, Message]  # type: ignore[type-arg]
 

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -445,10 +445,10 @@ async def _consume_and_reply(
         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
         if in_queue._broker_client.NAME.lower() != "rabbitmq":
             return
-        for raw_q in [pub.pub] + list(sub._subs.keys()):  # type: ignore[arg-type]
-            if raw_q.connection:
+        for raw_q in [pub.pub, sub._sub]:
+            if raw_q.connection:  # type: ignore[union-attr]
                 LOGGER.info("sending heartbeat to RabbitMQ broker...")
-                raw_q.connection.process_data_events()
+                raw_q.connection.process_data_events()  # type: ignore[union-attr]
 
     # GO!
     total_msg_count = 0

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -432,12 +432,8 @@ async def _consume_and_reply(
     pending: AsyncioTaskMessages = {}
     task_errors: List[BaseException] = []
 
-    # for the first (set) of messages, use 'timeout_wait_for_first_message' if given
-    in_queue.timeout = (
-        timeout_wait_for_first_message
-        if timeout_wait_for_first_message
-        else timeout_incoming
-    )
+    # for the first messages, use 'timeout_wait_for_first_message' if given
+    in_queue.timeout = timeout_wait_for_first_message or timeout_incoming
 
     def housekeeping_fn() -> None:
         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
@@ -450,9 +446,7 @@ async def _consume_and_reply(
 
     # GO!
     total_msg_count = 0
-    LOGGER.info(
-        "Listening for messages from server to process tasks then send results..."
-    )
+    LOGGER.info("Listening for messages to process tasks then send results...")
     # open pub
     async with out_queue.open_pub() as pub:
         LOGGER.info(f"Processing up to {multitasking} tasks concurrently")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -508,6 +508,7 @@ async def _consume_and_reply(
     # open pub & sub
     async with out_queue.open_pub() as pub, in_queue.open_sub_manual_acking() as sub:
         LOGGER.info(f"Processing up to {multitasking} tasks concurrently")
+        message_iterator = sub.iter_messages()
         #
         # "listener loop" -- get messages and do tasks
         # intermittently halting to process housekeeping things
@@ -524,7 +525,7 @@ async def _consume_and_reply(
             else:
                 LOGGER.debug("Listening for incoming message...")
                 try:
-                    in_msg = await anext(sub.iter_messages())  # -> in_queue.timeout
+                    in_msg = await anext(message_iterator)  # -> in_queue.timeout
                     msg_waittime_current = 0.0
                     total_msg_count += 1
                     LOGGER.info(f"Got a task to process (#{total_msg_count}): {in_msg}")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -501,7 +501,7 @@ async def _consume_and_reply(
                     )
                 )
                 pending[task] = in_msg
-            except StopIteration:
+            except StopAsyncIteration:
                 # no message this round
                 pass
 

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -427,14 +427,13 @@ class Housekeeping:
     def __init__(self) -> None:
         self.prev_rabbitmq_heartbeat = 0.0
 
-    def work(
+    async def work(
         self,
         in_queue: mq.Queue,
         sub: mq.queue.ManualQueueSubResource,
         pub: mq.queue.QueuePubResource,
     ) -> None:
         """Do housekeeping."""
-
         # rabbitmq heartbeats
         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
         if in_queue._broker_client.NAME.lower() == "rabbitmq":
@@ -448,7 +447,8 @@ class Housekeeping:
                         LOGGER.info("sending heartbeat to RabbitMQ broker...")
                         raw_q.connection.process_data_events()  # type: ignore[attr-defined, union-attr]
 
-        # TODO -- add other housekeeping
+        # other housekeeping
+        await asyncio.sleep(0)  # hand over control to other async tasks
 
 
 async def _consume_and_reply(
@@ -517,8 +517,7 @@ async def _consume_and_reply(
         while not listener_loop_exit(
             task_errors, msg_waittime_current, msg_waittime_timeout
         ):
-            housekeeper.work(in_queue, sub, pub)
-            await asyncio.sleep(0)  # hand over control to other async tasks
+            await housekeeper.work(in_queue, sub, pub)
             #
             # get messages/tasks
             if len(pending) >= multitasking:
@@ -577,7 +576,7 @@ async def _consume_and_reply(
         if pending:
             LOGGER.debug("Waiting for remaining tasks to finish...")
         while pending:
-            housekeeper.work(in_queue, sub, pub)
+            await housekeeper.work(in_queue, sub, pub)
             # wait on finished task (or timeout)
             pending, task_errors = await _wait_on_tasks_with_ack(
                 sub,

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -349,6 +349,7 @@ async def _wait_on_tasks_with_ack(
         LOGGER.error(_all_task_errors_string(previous_task_errors))
 
     # wait for next task
+    LOGGER.info("Waiting on tasks...")
     done, pending = await asyncio.wait(
         pending,
         return_when=asyncio.FIRST_COMPLETED,
@@ -537,7 +538,6 @@ async def _consume_and_reply(
                     pass
 
             # wait on finished task (or housekeeping timeout)
-            LOGGER.info("Waiting on tasks...")
             pending, task_errors = await _wait_on_tasks_with_ack(
                 sub,
                 pub,

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -484,8 +484,9 @@ async def _consume_and_reply(
             #
             # get messages/tasks
             if len(pending) >= multitasking:
-                LOGGER.info("Reached max task concurrency limit, waiting...")
+                LOGGER.info("At max task concurrency limit")
             else:
+                LOGGER.info("Listening for incoming message...")
                 try:
                     in_msg = await anext(sub.iter_messages())  # -> in_queue.timeout
                     recent_msg_ts = time.time()
@@ -512,11 +513,13 @@ async def _consume_and_reply(
                         )
                     )
                     pending[task] = in_msg
+                    continue  # we got one message, so maybe the queue is saturated
                 except StopAsyncIteration:
                     # no message this round
                     pass
 
             # wait on finished task (or housekeeping timeout)
+            LOGGER.info("Waiting on tasks...")
             pending, task_errors = await _wait_on_tasks_with_ack(
                 sub,
                 pub,

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -556,7 +556,7 @@ async def _consume_and_reply(
                     #   not worry about time not spent waiting for a message
                     current_msg_waittime += in_queue.timeout
 
-            # wait on finished task (or housekeeping timeout)
+            # wait on finished task (or timeout)
             pending, task_errors = await _wait_on_tasks_with_ack(
                 sub,
                 pub,
@@ -572,7 +572,7 @@ async def _consume_and_reply(
         while pending:
             housekeeper.work(in_queue, sub, pub)
             LOGGER.info("Waiting for remaining tasks to finish...")
-            # wait on finished task (or housekeeping timeout)
+            # wait on finished task (or timeout)
             pending, task_errors = await _wait_on_tasks_with_ack(
                 sub,
                 pub,

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -406,14 +406,14 @@ async def _wait_on_tasks_with_ack(
 
 def listener_loop_exit(
     task_errors: List[BaseException],
-    recent_msg_ts: float,
+    current_msg_waittime: float,
     listener_loop_timeout: float,
 ) -> bool:
     """Essentially a big IF condition -- but now with logging!"""
     if task_errors:
         LOGGER.info("1+ Tasks Failed: waiting for remaining tasks")
         return True
-    if time.time() - recent_msg_ts > listener_loop_timeout:
+    if current_msg_waittime > listener_loop_timeout:
         LOGGER.info(f"Timed out waiting for incoming message: {listener_loop_timeout=}")
         return True
     return False
@@ -510,7 +510,7 @@ async def _consume_and_reply(
         LOGGER.info(f"Processing up to {multitasking} tasks concurrently")
         #
         # "listener loop" -- get messages and do tasks
-        # intermittently halt listening to process housekeeping things
+        # intermittently halting to process housekeeping things
         #
         current_msg_waittime = 0.0
         while not listener_loop_exit(
@@ -567,7 +567,7 @@ async def _consume_and_reply(
 
         #
         # "clean up loop" -- wait for remaining tasks
-        # intermittently halt listening to process housekeeping things
+        # intermittently halting to process housekeeping things
         #
         while pending:
             housekeeper.work(in_queue, sub, pub)

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -444,12 +444,11 @@ async def _consume_and_reply(
 
     def housekeeping_fn() -> None:
         # TODO: replace when https://github.com/Observation-Management-Service/MQClient/issues/56
-        if in_queue._broker_client.NAME.lower() != "rabbitmq":
-            return
-        for raw_q in [pub.pub, sub._sub]:
-            if raw_q.connection:  # type: ignore[union-attr]
-                LOGGER.info("sending heartbeat to RabbitMQ broker...")
-                raw_q.connection.process_data_events()  # type: ignore[union-attr]
+        if in_queue._broker_client.NAME.lower() == "rabbitmq":
+            for raw_q in [pub.pub, sub._sub]:
+                if raw_q.connection:  # type: ignore[union-attr]
+                    LOGGER.info("sending heartbeat to RabbitMQ broker...")
+                    raw_q.connection.process_data_events()  # type: ignore[union-attr]
 
     def did_timeout(time_of_last_message: float, timeout: float) -> bool:
         if time.time() - time_of_last_message > timeout:

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -556,6 +556,7 @@ async def _consume_and_reply(
                     #   incrementing by the timeout value allows us to
                     #   not worry about time not spent waiting for a message
                     msg_waittime_current += in_queue.timeout
+                    message_iterator = sub.iter_messages()
 
             # wait on finished task (or timeout)
             pending, task_errors = await _wait_on_tasks_with_ack(

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -860,6 +860,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                 queue_outgoing=queue_outgoing,
                 ftype_to_subproc=FileType.TXT,
                 ftype_from_subproc=FileType.TXT,
+                timeout_incoming=refresh_interval_rabbitmq_heartbeat_interval * 1.5,
                 # file_writer=UniversalFileInterface.write, # see other tests
                 # file_reader=UniversalFileInterface.read, # see other tests
                 debug_dir=debug_dir if use_debug_dir else None,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -739,7 +739,7 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
         assert_debug_dir(
             debug_dir,
             FileType.TXT,
-            len(msgs_outgoing_expected),
+            MULTITASKING,
             ["in", "out", "stderrfile", "stdoutfile"],
         )
     # check for persisted files
@@ -880,7 +880,7 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
         assert_debug_dir(
             debug_dir,
             FileType.TXT,
-            len(msgs_outgoing_expected),
+            MULTITASKING,
             ["in", "out", "stderrfile", "stdoutfile"],
         )
     # check for persisted files

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -820,7 +820,7 @@ TEST_1000_SLEEP = 150.0  # anything lower doesn't upset rabbitmq enough
 @pytest.mark.usefixtures("unique_pwd")
 @pytest.mark.parametrize("use_debug_dir", [True, False])
 @pytest.mark.parametrize(
-    "housekeeping_timeout",
+    "rabbitmq_heartbeat_interval",
     [
         TEST_1000_SLEEP * 10,
         TEST_1000_SLEEP,
@@ -833,7 +833,7 @@ async def test_1000__rabbitmq_heartbeat_workaround(
     debug_dir: Path,
     first_walk: OSWalkList,
     use_debug_dir: bool,
-    housekeeping_timeout: float,
+    rabbitmq_heartbeat_interval: float,
 ) -> None:
     """Test a normal .txt-based pilot."""
     if config.ENV.EWMS_PILOT_BROKER_CLIENT != "rabbitmq":
@@ -869,9 +869,9 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     # run producer & consumer concurrently
     with patch(
         "ewms_pilot.pilot.Housekeeping.RABBITMQ_HEARTBEAT_INTERVAL",
-        housekeeping_timeout,
+        rabbitmq_heartbeat_interval,
     ):
-        if housekeeping_timeout > TEST_1000_SLEEP:
+        if rabbitmq_heartbeat_interval > TEST_1000_SLEEP:
             with pytest.raises(
                 RuntimeError,
                 match=re.escape(
@@ -887,7 +887,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                         len([]),
                         ["in", "out", "stderrfile", "stdoutfile"],
                     )
-        elif housekeeping_timeout == TEST_1000_SLEEP:
+        elif rabbitmq_heartbeat_interval == TEST_1000_SLEEP:
             with pytest.raises(mq.broker_client_interface.ClosingFailedException):
                 await _test()
                 await assert_results(queue_outgoing, [])
@@ -898,7 +898,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                         len([]),
                         ["in", "out", "stderrfile", "stdoutfile"],
                     )
-        else:  # housekeeping_timeout < TEST_1000_SLEEP
+        else:  # rabbitmq_heartbeat_interval < TEST_1000_SLEEP
             await _test()
             await assert_results(queue_outgoing, msgs_outgoing_expected)
             if use_debug_dir:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -890,9 +890,10 @@ TEST_1000_SLEEP = 150.0  # anything lower doesn't upset rabbitmq enough
 @pytest.mark.parametrize(
     "refresh_interval_rabbitmq_heartbeat_interval",
     [
-        TEST_1000_SLEEP * 10,
-        TEST_1000_SLEEP,
-        TEST_1000_SLEEP / 10,
+        # note -- the broker hb timeout is ~1 min and is triggered after ~2x
+        TEST_1000_SLEEP * 10,  # won't actually wait this long
+        TEST_1000_SLEEP,  # ~= to ~2x (see above)
+        TEST_1000_SLEEP / 10,  # will have no hb issues
     ],
 )
 async def test_1000__rabbitmq_heartbeat_workaround(

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -689,8 +689,8 @@ async def test_510__concurrent_load_multitasking_exceptions(
     with pytest.raises(
         RuntimeError,
         match=re.escape(f"{MULTITASKING} TASK(S) FAILED: ")
-        + ", ".join(
-            rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
+        + ", ".join(  # b/c we don't guarantee in-order delivery, we cannot assert which messages each subproc failed on
+            r"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: [^']+'\)"
             for _ in range(MULTITASKING)
         ),
     ) as e:
@@ -837,8 +837,8 @@ async def test_530__preload_multitasking_exceptions(
     with pytest.raises(
         RuntimeError,
         match=re.escape(f"{MULTITASKING} TASK(S) FAILED: ")
-        + ", ".join(
-            rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
+        + ", ".join(  # b/c we don't guarantee in-order delivery, we cannot assert which messages each subproc failed on
+            r"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: [^']+'\)"
             for _ in range(MULTITASKING)
         ),
     ) as e:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -724,7 +724,7 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
         )
     # check each exception only occurred n-times -- much easier this way than regex (lots of permutations)
     # we already know there are MULTITASKING subproc errors
-    for msg in range(msgs_outgoing_expected):
+    for msg in msgs_outgoing_expected:
         assert str(e.value).count(f"ValueError: gotta fail: {msg.strip()}") <= 1
 
     # it should've taken ~5 seconds to complete all tasks (but we're on 1 cpu so it takes longer)
@@ -861,7 +861,7 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
         )
     # check each exception only occurred n-times -- much easier this way than regex (lots of permutations)
     # we already know there are MULTITASKING subproc errors
-    for msg in range(msgs_outgoing_expected):
+    for msg in msgs_outgoing_expected:
         assert str(e.value).count(f"ValueError: gotta fail: {msg.strip()}") <= 1
 
     # it should've taken ~5 seconds to complete all tasks (but we're on 1 cpu so it takes longer)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -78,6 +78,8 @@ async def populate_queue(
 
     async with to_client_q.open_pub() as pub:
         for i, msg in enumerate(msgs_to_subproc):
+            if not i % 2:  # add some chaos -- make the queue not saturated
+                await asyncio.sleep(1)
             await pub.send(msg)
 
     assert i + 1 == len(msgs_to_subproc)  # pylint:disable=undefined-loop-variable

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -411,9 +411,7 @@ async def test_300__writer_reader(
 ) -> None:
     """Test a normal .txt-based pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [
-        f"output: {reversed(x)}{reversed(x)}\n" for x in MSGS_TO_SUBPROC
-    ]
+    msgs_outgoing_expected = [f"output: {x[::-1]}{x[::-1]}\n" for x in MSGS_TO_SUBPROC]
 
     def reverse_writer(text: Any, fpath: Path) -> None:
         with open(fpath, "w") as f:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -723,13 +723,9 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
             ),
         )
     # check each exception only occurred n-times -- much easier this way than regex (lots of permutations)
-    for i in range(MULTITASKING):
-        assert (
-            str(e.value).count(
-                f"ValueError: gotta fail: {msgs_outgoing_expected[i].strip()}"
-            )
-            == 1
-        )
+    # we already know there are MULTITASKING subproc errors
+    for msg in range(msgs_outgoing_expected):
+        assert str(e.value).count(f"ValueError: gotta fail: {msg.strip()}") <= 1
 
     # it should've taken ~5 seconds to complete all tasks (but we're on 1 cpu so it takes longer)
     print(time.time() - start_time)
@@ -864,13 +860,9 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
             multitasking=MULTITASKING,
         )
     # check each exception only occurred n-times -- much easier this way than regex (lots of permutations)
-    for i in range(MULTITASKING):
-        assert (
-            str(e.value).count(
-                f"ValueError: gotta fail: {msgs_outgoing_expected[i].strip()}"
-            )
-            == 1
-        )
+    # we already know there are MULTITASKING subproc errors
+    for msg in range(msgs_outgoing_expected):
+        assert str(e.value).count(f"ValueError: gotta fail: {msg.strip()}") <= 1
 
     # it should've taken ~5 seconds to complete all tasks (but we're on 1 cpu so it takes longer)
     print(time.time() - start_time)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -820,7 +820,7 @@ TEST_1000_SLEEP = 150.0  # anything lower doesn't upset rabbitmq enough
 @pytest.mark.usefixtures("unique_pwd")
 @pytest.mark.parametrize("use_debug_dir", [True, False])
 @pytest.mark.parametrize(
-    "rabbitmq_heartbeat_interval",
+    "refresh_interval_rabbitmq_heartbeat_interval",
     [
         TEST_1000_SLEEP * 10,
         TEST_1000_SLEEP,
@@ -833,7 +833,7 @@ async def test_1000__rabbitmq_heartbeat_workaround(
     debug_dir: Path,
     first_walk: OSWalkList,
     use_debug_dir: bool,
-    rabbitmq_heartbeat_interval: float,
+    refresh_interval_rabbitmq_heartbeat_interval: float,
 ) -> None:
     """Test a normal .txt-based pilot."""
     if config.ENV.EWMS_PILOT_BROKER_CLIENT != "rabbitmq":
@@ -868,10 +868,13 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 
     # run producer & consumer concurrently
     with patch(
+        "ewms_pilot.pilot._REFRESH_INTERVAL",
+        refresh_interval_rabbitmq_heartbeat_interval,
+    ), patch(
         "ewms_pilot.pilot.Housekeeping.RABBITMQ_HEARTBEAT_INTERVAL",
-        rabbitmq_heartbeat_interval,
+        refresh_interval_rabbitmq_heartbeat_interval,
     ):
-        if rabbitmq_heartbeat_interval > TEST_1000_SLEEP:
+        if refresh_interval_rabbitmq_heartbeat_interval > TEST_1000_SLEEP:
             with pytest.raises(
                 RuntimeError,
                 match=re.escape(
@@ -887,7 +890,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                         len([]),
                         ["in", "out", "stderrfile", "stdoutfile"],
                     )
-        elif rabbitmq_heartbeat_interval == TEST_1000_SLEEP:
+        elif refresh_interval_rabbitmq_heartbeat_interval == TEST_1000_SLEEP:
             with pytest.raises(mq.broker_client_interface.ClosingFailedException):
                 await _test()
                 await assert_results(queue_outgoing, [])
@@ -898,7 +901,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                         len([]),
                         ["in", "out", "stderrfile", "stdoutfile"],
                     )
-        else:  # rabbitmq_heartbeat_interval < TEST_1000_SLEEP
+        else:  # refresh_interval_rabbitmq_heartbeat_interval < TEST_1000_SLEEP
             await _test()
             await assert_results(queue_outgoing, msgs_outgoing_expected)
             if use_debug_dir:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -860,7 +860,9 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
                 queue_outgoing=queue_outgoing,
                 ftype_to_subproc=FileType.TXT,
                 ftype_from_subproc=FileType.TXT,
-                timeout_incoming=refresh_interval_rabbitmq_heartbeat_interval * 1.5,
+                timeout_incoming=int(
+                    refresh_interval_rabbitmq_heartbeat_interval * 1.5
+                ),
                 # file_writer=UniversalFileInterface.write, # see other tests
                 # file_reader=UniversalFileInterface.read, # see other tests
                 debug_dir=debug_dir if use_debug_dir else None,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -82,7 +82,7 @@ async def populate_queue(
 
     async with to_client_q.open_pub() as pub:
         for i, msg in enumerate(msgs_to_subproc):
-            if not i % 2:  # add some chaos -- make the queue not saturated
+            if i and i % 2 == 0:  # add some chaos -- make the queue not saturated
                 await asyncio.sleep(timeout_incoming / 2)
             await pub.send(msg)
 

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -26,6 +26,8 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 
 TIMEOUT_INCOMING = 3
 
+MSGS_TO_SUBPROC = ["item" + str(i) for i in range(30)]
+
 
 @pytest.fixture
 def queue_incoming() -> str:
@@ -179,8 +181,8 @@ async def test_000__txt(
     use_debug_dir: bool,
 ) -> None:
     """Test a normal .txt-based pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     # run producer & consumer concurrently
     await asyncio.gather(
@@ -232,8 +234,8 @@ async def test_001__txt__str_filetype(
     use_debug_dir: bool,
 ) -> None:
     """Test a normal .txt-based pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     # run producer & consumer concurrently
     await asyncio.gather(
@@ -287,10 +289,8 @@ async def test_100__json(
     """Test a normal .json-based pilot."""
 
     # some messages that would make sense json'ing
-    msgs_to_subproc = [{"attr-0": v} for v in ["foo", "bar", "baz"]]
-    msgs_outgoing_expected = [
-        {"attr-a": v, "attr-b": v + v} for v in ["foo", "bar", "baz"]
-    ]
+    msgs_to_subproc = [{"attr-0": v} for v in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [{"attr-a": v, "attr-b": v + v} for v in MSGS_TO_SUBPROC]
 
     # run producer & consumer concurrently
     await asyncio.gather(
@@ -347,7 +347,14 @@ async def test_200__pickle(
     """Test a normal .pkl-based pilot."""
 
     # some messages that would make sense pickling
-    msgs_to_subproc = [date(1995, 12, 3), date(2022, 9, 29), date(2063, 4, 5)]
+    msgs_to_subproc = [
+        date(
+            1995 + int(re.sub(r"[^0-9]", "", x)),
+            int(re.sub(r"[^0-9]", "", x)) % 12 + 1,
+            int(re.sub(r"[^0-9]", "", x)) % 28 + 1,
+        )
+        for x in MSGS_TO_SUBPROC
+    ]
     msgs_outgoing_expected = [d + timedelta(days=1) for d in msgs_to_subproc]
 
     # run producer & consumer concurrently
@@ -403,11 +410,9 @@ async def test_300__writer_reader(
     use_debug_dir: bool,
 ) -> None:
     """Test a normal .txt-based pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
     msgs_outgoing_expected = [
-        "output: oofoof\n",
-        "output: rabrab\n",
-        "output: zabzab\n",
+        f"output: {reversed(x)}{reversed(x)}\n" for x in MSGS_TO_SUBPROC
     ]
 
     def reverse_writer(text: Any, fpath: Path) -> None:
@@ -470,8 +475,8 @@ async def test_400__exception(
     quarantine: Optional[int],
 ) -> None:
     """Test a normal .txt-based pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    # msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    # msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -534,8 +539,8 @@ async def test_420__timeout(
     use_debug_dir: bool,
 ) -> None:
     """Test a normal .txt-based pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    # msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    # msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -611,8 +616,8 @@ async def test_500__concurrent_load_multitasking(
     prefetch: int,
 ) -> None:
     """Test multitasking within the pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -675,8 +680,8 @@ async def test_510__concurrent_load_multitasking_exceptions(
     prefetch: int,
 ) -> None:
     """Test multitasking within the pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -751,8 +756,8 @@ async def test_520__preload_multitasking(
     prefetch: int,
 ) -> None:
     """Test multitasking within the pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -813,8 +818,8 @@ async def test_530__preload_multitasking_exceptions(
     prefetch: int,
 ) -> None:
     """Test multitasking within the pilot."""
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     start_time = time.time()
 
@@ -900,8 +905,8 @@ async def test_1000__rabbitmq_heartbeat_workaround(
     if config.ENV.EWMS_PILOT_BROKER_CLIENT != "rabbitmq":
         return
 
-    msgs_to_subproc = ["foo", "bar", "baz"]
-    msgs_outgoing_expected = ["foofoo\n", "barbar\n", "bazbaz\n"]
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
 
     timeout_incoming = int(refresh_interval_rabbitmq_heartbeat_interval * 1.5)
 

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -686,7 +686,7 @@ async def test_510__concurrent_load_multitasking_exceptions(
     # run producer & consumer concurrently
     with pytest.raises(
         RuntimeError,
-        match=f"{MULTITASKING} TASK(S) FAILED: "
+        match=re.escape(f"{MULTITASKING} TASK(S) FAILED: ")
         + ", ".join(
             rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
             for _ in range(MULTITASKING)
@@ -834,7 +834,7 @@ async def test_530__preload_multitasking_exceptions(
 
     with pytest.raises(
         RuntimeError,
-        match=f"{MULTITASKING} TASK(S) FAILED: "
+        match=re.escape(f"{MULTITASKING} TASK(S) FAILED: ")
         + ", ".join(
             rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
             for _ in range(MULTITASKING)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -867,7 +867,10 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
         )
 
     # run producer & consumer concurrently
-    with patch("ewms_pilot.pilot._HOUSEKEEPING_TIMEOUT", housekeeping_timeout):
+    with patch(
+        "ewms_pilot.pilot.Housekeeping.RABBITMQ_HEARTBEAT_INTERVAL",
+        housekeeping_timeout,
+    ):
         if housekeeping_timeout > TEST_1000_SLEEP:
             with pytest.raises(
                 RuntimeError,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -688,7 +688,7 @@ async def test_510__concurrent_load_multitasking_exceptions(
         RuntimeError,
         match=f"{MULTITASKING} TASK(S) FAILED: "
         + ", ".join(
-            r"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: .*'\)"
+            rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
             for _ in range(MULTITASKING)
         ),
     ) as e:
@@ -836,7 +836,7 @@ async def test_530__preload_multitasking_exceptions(
         RuntimeError,
         match=f"{MULTITASKING} TASK(S) FAILED: "
         + ", ".join(
-            r"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: .*'\)"
+            rf"TaskSubprocessError\('Subprocess completed with exit code 1: ValueError: gotta fail: ({'|'.join(x.strip() for x in msgs_outgoing_expected[:MULTITASKING])})'\)"
             for _ in range(MULTITASKING)
         ),
     ) as e:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -907,7 +907,8 @@ async def test_1000__rabbitmq_heartbeat_workaround(
     if config.ENV.EWMS_PILOT_BROKER_CLIENT != "rabbitmq":
         return
 
-    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_to_subproc = MSGS_TO_SUBPROC[:2]
+    # ^^^ should be sufficient plus avoids waiting for all to send
     msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     timeout_incoming = int(refresh_interval_rabbitmq_heartbeat_interval * 1.5)

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -184,7 +184,7 @@ async def test_000__txt(
 ) -> None:
     """Test a normal .txt-based pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     # run producer & consumer concurrently
     await asyncio.gather(
@@ -237,7 +237,7 @@ async def test_001__txt__str_filetype(
 ) -> None:
     """Test a normal .txt-based pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     # run producer & consumer concurrently
     await asyncio.gather(
@@ -476,7 +476,7 @@ async def test_400__exception(
 ) -> None:
     """Test a normal .txt-based pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    # msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    # msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -540,7 +540,7 @@ async def test_420__timeout(
 ) -> None:
     """Test a normal .txt-based pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    # msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    # msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -617,7 +617,7 @@ async def test_500__concurrent_load_multitasking(
 ) -> None:
     """Test multitasking within the pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -681,7 +681,7 @@ async def test_510__concurrent_load_multitasking_exceptions(
 ) -> None:
     """Test multitasking within the pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -758,7 +758,7 @@ async def test_520__preload_multitasking(
 ) -> None:
     """Test multitasking within the pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -820,7 +820,7 @@ async def test_530__preload_multitasking_exceptions(
 ) -> None:
     """Test multitasking within the pilot."""
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     start_time = time.time()
 
@@ -908,7 +908,7 @@ async def test_1000__rabbitmq_heartbeat_workaround(
         return
 
     msgs_to_subproc = MSGS_TO_SUBPROC
-    msgs_outgoing_expected = [f"{x}{x}\n" for x in MSGS_TO_SUBPROC]
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
 
     timeout_incoming = int(refresh_interval_rabbitmq_heartbeat_interval * 1.5)
 

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -85,7 +85,9 @@ async def populate_queue(
     async with to_client_q.open_pub() as pub:
         for i, msg in enumerate(msgs_to_subproc):
             if i and i % 2 == 0:  # add some chaos -- make the queue not saturated
-                await asyncio.sleep(timeout_incoming / 2)
+                await asyncio.sleep(timeout_incoming / 4)
+            else:
+                await asyncio.sleep(0)  # for consistency
             await pub.send(msg)
 
     assert i + 1 == len(msgs_to_subproc)  # pylint:disable=undefined-loop-variable


### PR DESCRIPTION
as seen in https://github.com/icecube/skymap_scanner/actions/runs/6151584209/job/16692007879?pr=199, when the tasks are long, and delayed/heterogeneous/async the heartbeat miss may happen when waiting for new messages rather than during task processing. IOW, we cannot assume the pilot is always saturated

Housekeeping is also expanded to support future situations.

The heartbeat interval is decreased to 5 sec which will have no impact on the broker, but will free up some networking / log space