### PR TITLE
Optionally Dump Subprocess Output On Task Finish [minor]

### DIFF
--- a/ewms_pilot/__main__.py
+++ b/ewms_pilot/__main__.py
@@ -107,7 +107,7 @@ def main() -> None:
         help="amount of time to sleep after error (useful for preventing blackhole scenarios on condor)",
     )
 
-    # logging args
+    # logging/debugging args
     parser.add_argument(
         "-l",
         "--log",
@@ -119,8 +119,12 @@ def main() -> None:
         default=ENV.EWMS_PILOT_LOG_THIRD_PARTY,
         help="the output logging level for third-party loggers",
     )
-
-    # testing/debugging args
+    parser.add_argument(
+        "--dump_subproc_output",
+        default=ENV.EWMS_PILOT_DUMP_SUBPROC_OUTPUT,
+        action="store_true",
+        help="dump each subprocess's stderr to stderr and stdout to stdout",
+    )
     parser.add_argument(
         "--debug-directory",
         default="",

--- a/ewms_pilot/__main__.py
+++ b/ewms_pilot/__main__.py
@@ -12,27 +12,27 @@ from .pilot import consume_and_reply
 
 
 def main() -> None:
-    """Start up EWMS Pilot subprocess to perform an MQ task."""
+    """Start up EWMS Pilot to do tasks, communicate via message passing."""
 
     parser = argparse.ArgumentParser(
-        description="Start up EWMS Pilot subprocess to perform an MQ task",
+        description="Start up EWMS Pilot task to perform an MQ task",
         epilog="",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "--cmd",  # alternatively we can go with a condor-like --executable and --arguments
         required=True,
-        help="the command to give the subprocess script",
+        help="the command to give the task script",
     )
     parser.add_argument(
         "--infile-type",
         type=FileType,
-        help="the file type (extension) to use for files written for the pilot's subprocess",
+        help="the file type (extension) of the input file for the pilot's task",
     )
     parser.add_argument(
         "--outfile-type",
         type=FileType,
-        help="the file type (exception) of the file to read from the pilot's subprocess",
+        help="the file type (extension) of the output file from the pilot's task",
     )
     parser.add_argument(
         "--multitasking",

--- a/ewms_pilot/__main__.py
+++ b/ewms_pilot/__main__.py
@@ -120,10 +120,10 @@ def main() -> None:
         help="the output logging level for third-party loggers",
     )
     parser.add_argument(
-        "--dump-subproc-output",
-        default=ENV.EWMS_PILOT_DUMP_SUBPROC_OUTPUT,
+        "--dump-task-output",
+        default=ENV.EWMS_PILOT_DUMP_TASK_OUTPUT,
         action="store_true",
-        help="dump each subprocess's stderr to stderr and stdout to stdout",
+        help="dump each task's stderr to stderr and stdout to stdout",
     )
     parser.add_argument(
         "--debug-directory",

--- a/ewms_pilot/__main__.py
+++ b/ewms_pilot/__main__.py
@@ -120,7 +120,7 @@ def main() -> None:
         help="the output logging level for third-party loggers",
     )
     parser.add_argument(
-        "--dump_subproc_output",
+        "--dump-subproc-output",
         default=ENV.EWMS_PILOT_DUMP_SUBPROC_OUTPUT,
         action="store_true",
         help="dump each subprocess's stderr to stderr and stdout to stdout",

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -35,6 +35,7 @@ class EnvConfig:
     # logging
     EWMS_PILOT_LOG: str = "INFO"
     EWMS_PILOT_LOG_THIRD_PARTY: str = "WARNING"
+    EWMS_PILOT_DUMP_SUBPROC_OUTPUT: bool = False
 
     # chirp
     EWMS_PILOT_HTCHIRP: bool = False

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -35,7 +35,7 @@ class EnvConfig:
     # logging
     EWMS_PILOT_LOG: str = "INFO"
     EWMS_PILOT_LOG_THIRD_PARTY: str = "WARNING"
-    EWMS_PILOT_DUMP_SUBPROC_OUTPUT: bool = False
+    EWMS_PILOT_DUMP_TASK_OUTPUT: bool = False
 
     # chirp
     EWMS_PILOT_HTCHIRP: bool = False

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -61,7 +61,7 @@ async def consume_and_reply(
     file_reader: Callable[[Path], Any] = UniversalFileInterface.read,
     #
     debug_dir: Optional[Path] = None,
-    dump_subproc_output: bool = ENV.EWMS_PILOT_DUMP_SUBPROC_OUTPUT,
+    dump_task_output: bool = ENV.EWMS_PILOT_DUMP_TASK_OUTPUT,
     #
     task_timeout: Optional[int] = ENV.EWMS_PILOT_TASK_TIMEOUT,
     quarantine_time: int = ENV.EWMS_PILOT_QUARANTINE_TIME,
@@ -116,7 +116,7 @@ async def consume_and_reply(
             #
             debug_dir if debug_dir else Path("./tmp"),
             bool(debug_dir),
-            dump_subproc_output,
+            dump_task_output,
             #
             task_timeout,
             multitasking,
@@ -165,7 +165,7 @@ async def _consume_and_reply(
     #
     staging_dir: Path,
     keep_debug_dir: bool,
-    dump_subproc_output: bool,
+    dump_task_output: bool,
     #
     task_timeout: Optional[int],
     multitasking: int,
@@ -244,7 +244,7 @@ async def _consume_and_reply(
                             file_reader,
                             staging_dir,
                             keep_debug_dir,
-                            dump_subproc_output,
+                            dump_task_output,
                         )
                     )
                     pending[task] = in_msg

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -61,6 +61,7 @@ async def consume_and_reply(
     file_reader: Callable[[Path], Any] = UniversalFileInterface.read,
     #
     debug_dir: Optional[Path] = None,
+    dump_subproc_output: bool = ENV.EWMS_PILOT_DUMP_SUBPROC_OUTPUT,
     #
     task_timeout: Optional[int] = ENV.EWMS_PILOT_TASK_TIMEOUT,
     quarantine_time: int = ENV.EWMS_PILOT_QUARANTINE_TIME,
@@ -115,6 +116,7 @@ async def consume_and_reply(
             #
             debug_dir if debug_dir else Path("./tmp"),
             bool(debug_dir),
+            dump_subproc_output,
             #
             task_timeout,
             multitasking,
@@ -163,6 +165,7 @@ async def _consume_and_reply(
     #
     staging_dir: Path,
     keep_debug_dir: bool,
+    dump_subproc_output: bool,
     #
     task_timeout: Optional[int],
     multitasking: int,
@@ -241,6 +244,7 @@ async def _consume_and_reply(
                             file_reader,
                             staging_dir,
                             keep_debug_dir,
+                            dump_subproc_output,
                         )
                     )
                     pending[task] = in_msg

--- a/ewms_pilot/task.py
+++ b/ewms_pilot/task.py
@@ -73,7 +73,7 @@ async def process_msg_task(
     #
     staging_dir: Path,
     keep_debug_dir: bool,
-    dump_subproc_output: bool,
+    dump_task_output: bool,
 ) -> Any:
     """Process the message's task in a subprocess using `cmd` & respond."""
 
@@ -120,7 +120,7 @@ async def process_msg_task(
         LOGGER.error(f"Subprocess failed: {e}")  # log the time
         raise
     finally:
-        if dump_subproc_output:
+        if dump_task_output:
             _dump_binary_file(stdoutfile, sys.stdout)
             _dump_binary_file(stderrfile, sys.stderr)
 

--- a/ewms_pilot/task.py
+++ b/ewms_pilot/task.py
@@ -73,6 +73,7 @@ async def process_msg_task(
     #
     staging_dir: Path,
     keep_debug_dir: bool,
+    dump_subproc_output: bool,
 ) -> Any:
     """Process the message's task in a subprocess using `cmd` & respond."""
 
@@ -130,7 +131,8 @@ async def process_msg_task(
     if not keep_debug_dir:
         shutil.rmtree(staging_subdir)  # rm -r
 
-    _dump_binary_file(stdoutfile, sys.stdout)
-    _dump_binary_file(stderrfile, sys.stderr)
+    if dump_subproc_output:
+        _dump_binary_file(stdoutfile, sys.stdout)
+        _dump_binary_file(stderrfile, sys.stderr)
 
     return out_data

--- a/ewms_pilot/task.py
+++ b/ewms_pilot/task.py
@@ -57,7 +57,7 @@ def _dump_binary_file(fpath: Path, stream: TextIO) -> None:
                     break
                 stream.buffer.write(chunk)
     except Exception as e:
-        LOGGER.error(f"Error dumping subprocess output: {e}")
+        LOGGER.error(f"Error dumping subprocess output ({stream.name}): {e}")
 
 
 async def process_msg_task(
@@ -116,10 +116,13 @@ async def process_msg_task(
         if proc.returncode:
             raise TaskSubprocessError(proc.returncode, stderrfile)
 
-    # Error Case: first, if there's a file move it to debug dir (if enabled)
     except Exception as e:
         LOGGER.error(f"Subprocess failed: {e}")  # log the time
         raise
+    finally:
+        if dump_subproc_output:
+            _dump_binary_file(stdoutfile, sys.stdout)
+            _dump_binary_file(stderrfile, sys.stderr)
 
     # Successful Case: get message and move to debug dir
     out_data = file_reader(outfilepath)
@@ -130,9 +133,5 @@ async def process_msg_task(
     # cleanup -- on success only
     if not keep_debug_dir:
         shutil.rmtree(staging_subdir)  # rm -r
-
-    if dump_subproc_output:
-        _dump_binary_file(stdoutfile, sys.stdout)
-        _dump_binary_file(stderrfile, sys.stderr)
 
     return out_data


### PR DESCRIPTION
Adds `EWMS_PILOT_DUMP_TASK_OUTPUT`, `--dump-task-output`, and `dump_task_output` to control whether to dump each task's stderr to stderr and stdout to stdout.

see https://github.com/icecube/skymap_scanner/issues/193