### PR TITLE
Add `EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR` [minor]

### DIFF
--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -43,6 +43,7 @@ class EnvConfig:
     # meta
     EWMS_PILOT_INIT_TIMEOUT: Optional[int] = None
     EWMS_PILOT_TASK_TIMEOUT: Optional[int] = None
+    EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR: bool = True
     EWMS_PILOT_QUARANTINE_TIME: int = 0  # seconds
     EWMS_PILOT_CONCURRENT_TASKS: int = 1
     EWMS_PILOT_PREFETCH: int = 1  # off by default -- prefetch is an optimization
@@ -66,6 +67,16 @@ class EnvConfig:
                 " defaulting to '1'."
             )
             object.__setattr__(self, "EWMS_PILOT_CONCURRENT_TASKS", 1)  # b/c frozen
+
+        if (
+            self.EWMS_PILOT_QUARANTINE_TIME
+            and not self.EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR
+        ):
+            raise RuntimeError(
+                f"Cannot define 'EWMS_PILOT_QUARANTINE_TIME' while "
+                f"'EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR' is "
+                f"'{self.EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR}'"
+            )
 
 
 ENV = from_environment_as_dataclass(EnvConfig)

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -214,7 +214,7 @@ def listener_loop_exit(
     msg_waittime_timeout: float,
 ) -> bool:
     """Essentially a big IF condition -- but now with logging!"""
-    if task_errors:
+    if task_errors and ENV.EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR:
         LOGGER.info("1+ Tasks Failed: waiting for remaining tasks")
         return True
     if current_msg_waittime > msg_waittime_timeout:


### PR DESCRIPTION
By default, `EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR=True`. This retains the current behavior.

This environment variable, when set to `False`, optionally allows the pilot to ignore failed tasks as opposed to halting the message-listener component. The original message for the failed task will still be nacked. The pilot will exit when the listener times out, as it does for a batch of only non-failed tasks. The pilot will still exit with `1`, a raised `RuntimeError`.

In a future and/or alternative design, this variable could be a list of types of errors that stop the listener.