### PR TITLE
HTChirp: Use Enums for Status

### DIFF
--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -19,7 +19,7 @@ pika==1.3.2
 pulsar-client==3.1.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -33,14 +33,14 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
 └── certifi [required: Any, installed: 2023.7.22]
 setuptools==65.5.1

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -25,10 +25,10 @@ pulsar-client==3.1.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-retry==1.5.0
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -43,14 +43,14 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
 └── certifi [required: Any, installed: 2023.7.22]
 pytest-asyncio==0.21.1
@@ -63,7 +63,7 @@ pytest-retry==1.5.0
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
 ├── execnet [required: >=1.1, installed: 2.0.2]
 └── pytest [required: >=6.2.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -17,7 +17,7 @@ nkeys==0.1.0
 oms-mqclient==2.4.9
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -31,12 +31,12 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 nats-py==2.6.0
 nkeys==0.1.0
 └── ed25519 [required: Any, installed: 1.5]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
 wheel==0.41.3

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -15,7 +15,7 @@ oms-mqclient==2.4.9
 pulsar-client==3.1.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -29,10 +29,10 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pulsar-client==3.1.0
 └── certifi [required: Any, installed: 2023.7.22]
 setuptools==65.5.1

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -15,7 +15,7 @@ oms-mqclient==2.4.9
 pika==1.3.2
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -29,10 +29,10 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 pika==1.3.2
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
 wheel==0.41.3

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -20,10 +20,10 @@ pluggy==1.3.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-retry==1.5.0
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -38,10 +38,10 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 pytest-asyncio==0.21.1
 └── pytest [required: >=7.0.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
@@ -52,7 +52,7 @@ pytest-retry==1.5.0
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 23.2]
     └── pluggy [required: >=0.12,<2.0, installed: 1.3.0]
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
 ├── execnet [required: >=1.1, installed: 2.0.2]
 └── pytest [required: >=6.2.0, installed: 7.4.3]
     ├── iniconfig [required: Any, installed: 2.0.0]

--- a/dependencies.log
+++ b/dependencies.log
@@ -14,7 +14,7 @@ idna==3.4
 oms-mqclient==2.4.9
 requests==2.31.0
 typing_extensions==4.8.0
-urllib3==2.0.7
+urllib3==2.1.0
 wipac-dev-tools==1.7.1
 ########################################################################
 #  pipdeptree
@@ -28,9 +28,9 @@ ewms-pilot
         │   ├── certifi [required: >=2017.4.17, installed: 2023.7.22]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.4]
-        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.0.7]
+        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
         └── typing-extensions [required: Any, installed: 4.8.0]
 pip==23.2.1
-pipdeptree==2.13.0
+pipdeptree==2.13.1
 setuptools==65.5.1
 wheel==0.41.3

--- a/ewms_pilot/housekeeping.py
+++ b/ewms_pilot/housekeeping.py
@@ -10,7 +10,7 @@ import mqclient as mq
 from typing_extensions import ParamSpec
 
 from . import htchirp_tools
-from .config import ENV, LOGGER
+from .config import LOGGER
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/ewms_pilot/housekeeping.py
+++ b/ewms_pilot/housekeeping.py
@@ -52,17 +52,17 @@ class Housekeeping:
     @with_basic_housekeeping
     async def running_init_command(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Running init command")
+        self.chirper.chirp_status(htchirp_tools.PilotStatus.RunningInitCommand)
 
     @with_basic_housekeeping
     async def finished_init_command(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Finished init command")
+        pass
 
     @with_basic_housekeeping
     async def in_listener_loop(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Listening for incoming tasks")
+        self.chirper.chirp_status(htchirp_tools.PilotStatus.AwaitingFirstMessage)
 
     @with_basic_housekeeping
     async def queue_housekeeping(
@@ -91,13 +91,13 @@ class Housekeeping:
     @with_basic_housekeeping
     async def exited_listener_loop(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Done listening for incoming tasks")
+        pass
 
     @with_basic_housekeeping
     async def message_recieved(self, total_msg_count: int) -> None:
         """Update message count for chirp."""
         if total_msg_count == 1:
-            self.chirper.chirp_status("Tasking")
+            self.chirper.chirp_status(htchirp_tools.PilotStatus.Tasking)
         self.chirper.chirp_new_total(total_msg_count)
 
     @with_basic_housekeeping
@@ -107,14 +107,11 @@ class Housekeeping:
         self.chirper.chirp_new_success_total(n_success)
 
     @with_basic_housekeeping
-    async def waiting_for_remaining_tasks(self) -> None:
+    async def pending_remaining_tasks(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Waiting for remaining tasks")
+        self.chirper.chirp_status(htchirp_tools.PilotStatus.PendingRemainingTasks)
 
     @with_basic_housekeeping
     async def done_tasking(self) -> None:
         """Update status for chirp."""
-        self.chirper.chirp_status("Done with all tasks")
-        if ENV.EWMS_PILOT_HTCHIRP:
-            # at end: wait for chirp to be processed before teardown
-            await asyncio.sleep(5)
+        pass

--- a/ewms_pilot/housekeeping.py
+++ b/ewms_pilot/housekeeping.py
@@ -38,9 +38,6 @@ class Housekeeping:
     def __init__(self, chirper: htchirp_tools.Chirper) -> None:
         self.prev_rabbitmq_heartbeat = 0.0
         self.chirper = chirper
-        self.chirper.chirp_new_total(0)
-        self.chirper.chirp_new_failed_total(0)
-        self.chirper.chirp_new_success_total(0)
 
     async def basic_housekeeping(
         self,

--- a/ewms_pilot/housekeeping.py
+++ b/ewms_pilot/housekeeping.py
@@ -48,17 +48,17 @@ class Housekeeping:
 
     @with_basic_housekeeping
     async def running_init_command(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         self.chirper.chirp_status(htchirp_tools.PilotStatus.RunningInitCommand)
 
     @with_basic_housekeeping
     async def finished_init_command(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         pass
 
     @with_basic_housekeeping
     async def in_listener_loop(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         self.chirper.chirp_status(htchirp_tools.PilotStatus.AwaitingFirstMessage)
 
     @with_basic_housekeeping
@@ -87,7 +87,7 @@ class Housekeeping:
 
     @with_basic_housekeeping
     async def exited_listener_loop(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         pass
 
     @with_basic_housekeeping
@@ -105,10 +105,10 @@ class Housekeeping:
 
     @with_basic_housekeeping
     async def pending_remaining_tasks(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         self.chirper.chirp_status(htchirp_tools.PilotStatus.PendingRemainingTasks)
 
     @with_basic_housekeeping
     async def done_tasking(self) -> None:
-        """Update status for chirp."""
+        """Basic housekeeping + status chirping (if needed)."""
         pass

--- a/ewms_pilot/housekeeping.py
+++ b/ewms_pilot/housekeeping.py
@@ -57,7 +57,7 @@ class Housekeeping:
         pass
 
     @with_basic_housekeeping
-    async def in_listener_loop(self) -> None:
+    async def entered_listener_loop(self) -> None:
         """Basic housekeeping + status chirping (if needed)."""
         self.chirper.chirp_status(htchirp_tools.PilotStatus.AwaitingFirstMessage)
 

--- a/ewms_pilot/htchirp_tools.py
+++ b/ewms_pilot/htchirp_tools.py
@@ -137,6 +137,10 @@ class Chirper:
         if not ENV.EWMS_PILOT_HTCHIRP:
             return
 
+        if not total:
+            # total can only increase -> can be inferred total=0 if attr is absent
+            return
+
         self._backlog[HTChirpAttr.HTChirpEWMSPilotTasksTotal] = total
         self._chirp_backlog(is_rate_limited=True)
 
@@ -148,6 +152,10 @@ class Chirper:
         if not ENV.EWMS_PILOT_HTCHIRP:
             return
 
+        if not total:
+            # total can only increase -> can be inferred total=0 if attr is absent
+            return
+
         self._backlog[HTChirpAttr.HTChirpEWMSPilotTasksSuccess] = total
         self._chirp_backlog(is_rate_limited=True)
 
@@ -157,6 +165,10 @@ class Chirper:
         This chirp is enqueued (rate limited) and sent every X seconds.
         """
         if not ENV.EWMS_PILOT_HTCHIRP:
+            return
+
+        if not total:
+            # total can only increase -> can be inferred total=0 if attr is absent
             return
 
         self._backlog[HTChirpAttr.HTChirpEWMSPilotTasksFailed] = total

--- a/ewms_pilot/htchirp_tools.py
+++ b/ewms_pilot/htchirp_tools.py
@@ -120,7 +120,6 @@ class Chirper:
             return
 
         self._backlog[HTChirpAttr.HTChirpEWMSPilotStatus] = status.name
-        # TODO - ts for specific status
         self._chirp_backlog()
 
     def chirp_new_total(self, total: int) -> None:

--- a/ewms_pilot/htchirp_tools.py
+++ b/ewms_pilot/htchirp_tools.py
@@ -107,6 +107,7 @@ class Chirper:
                 _set_job_attr(conn, bl_attr.name, bl_value)
                 if not bl_attr.name.endswith("Timestamp"):
                     # NOTE - the timestamp is when the chirp is sent, not when the attr was put into backlog
+                    # NOTE - if overhead is too high, append ts to front of string
                     _set_job_attr(conn, f"{bl_attr.name}_Timestamp", int(time.time()))
                 self._backlog.pop(bl_attr)  # wait to remove until success
         except Exception as e:

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -293,7 +293,7 @@ async def _consume_and_reply(
     async with out_queue.open_pub() as pub, in_queue.open_sub_manual_acking() as sub:
         LOGGER.info(f"Processing up to {multitasking} tasks concurrently")
         message_iterator = sub.iter_messages()
-        await housekeeper.in_listener_loop()
+        await housekeeper.entered_listener_loop()
         #
         # "listener loop" -- get messages and do tasks
         # intermittently halting to process housekeeping things


### PR DESCRIPTION
Changes `HTChirpEWMSPilotStatus` to an enum (constant str), which is useful for reporting and cluster-level aggregation.

Also optimizes chirping by eliminating attributes, highlights include:
- no longer chirp totals of `0` (total can only increase -> can be inferred total=0 if attr is absent)
- only send one timestamp attribute (new: `HTChirpEWMSPilotLastUpdatedTimestamp`) per "batch" of chirps
   * if the report viewer needs additional granularity, much can be inferred by using status and client-side tracking