### PR TITLE
HTChirp: Send Backlog at End

### DIFF
--- a/ewms_pilot/htchirp_tools.py
+++ b/ewms_pilot/htchirp_tools.py
@@ -99,6 +99,9 @@ class Chirper:
     async def chirp_backlog_until_done(self, total_time: int, sleep: int) -> float:
         """Call `chirp_backlog()` until backlog is all sent successfully.
 
+        Total time may take a little bit longer than `total_time`,
+        depending on the `sleep` value and the runtime of `chirp_backlog()`.
+
         Return the amount of time leftover from `total_time`.
         """
         if not ENV.EWMS_PILOT_HTCHIRP:
@@ -125,11 +128,14 @@ class Chirper:
         ):
             return
 
+        # set HTChirpEWMSPilotLastUpdatedTimestamp & verify backlog
+        self._backlog.pop(HTChirpAttr.HTChirpEWMSPilotLastUpdatedTimestamp, None)
+        if not self._backlog:
+            return  # nothing to chirp
         now = int(time.time())
         self._backlog[HTChirpAttr.HTChirpEWMSPilotLastUpdatedTimestamp] = now
-        if len(self._backlog) == 1:
-            return  # nothing to chirp
 
+        # chirp it all
         try:
             conn = self._get_conn()
             for bl_attr, bl_value in list(self._backlog.items()):

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -4,7 +4,6 @@
 import asyncio
 import shutil
 import sys
-import time
 import uuid
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -4,6 +4,7 @@
 import asyncio
 import shutil
 import sys
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Union
@@ -156,7 +157,10 @@ async def consume_and_reply(
         chirper.chirp_status(htchirp_tools.PilotStatus.FatalError)
         if quarantine_time:
             LOGGER.warning(f"Quarantining for {quarantine_time} seconds")
-            await asyncio.sleep(quarantine_time)
+            start = time.time()
+            while time.time() - start < quarantine_time:
+                await asyncio.sleep(5)
+                chirper.chirp_backlog()
         raise
     else:
         chirper.chirp_status(htchirp_tools.PilotStatus.Done)


### PR DESCRIPTION
Chirps may fail to send, but the backlog should be sent at the end of the pilot, with good effort.