### PR TITLE
Update for Semicolon-Delimited Queues (Multi-Queue Off)

### DIFF
--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -6,19 +6,18 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
-ed25519==1.5
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 nats-py==2.7.2
-nkeys==0.1.0
+nkeys==0.2.0
 oms-mqclient==2.4.10
 pika==1.3.2
 pulsar-client==3.1.0
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -26,23 +25,22 @@ wipac-dev-tools==1.9.1
 ########################################################################
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 nats-py==2.7.2
-nkeys==0.1.0
-└── ed25519 [required: Any, installed: 1.5]
+nkeys==0.2.0
 pika==1.3.2
-pipdeptree==2.19.1
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2024.2.2]
+└── certifi [required: Any, installed: 2024.6.2]
 setuptools==65.5.1
 wheel==0.43.0

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -7,27 +7,26 @@
 #  pip freeze
 ########################################################################
 asyncstdlib==3.12.3
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
-ed25519==1.5
 execnet==2.1.1
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 iniconfig==2.0.0
 nats-py==2.7.2
-nkeys==0.1.0
+nkeys==0.2.0
 oms-mqclient==2.4.10
 packaging==24.0
 pika==1.3.2
 pluggy==1.5.0
 pulsar-client==3.1.0
-pytest==8.2.0
-pytest-asyncio==0.23.6
-pytest-retry==1.6.2
+pytest==8.2.1
+pytest-asyncio==0.23.7
+pytest-retry==1.6.3
 pytest-xdist==3.6.1
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -36,37 +35,36 @@ wipac-dev-tools==1.9.1
 asyncstdlib==3.12.3
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 nats-py==2.7.2
-nkeys==0.1.0
-└── ed25519 [required: Any, installed: 1.5]
+nkeys==0.2.0
 pika==1.3.2
-pipdeptree==2.19.1
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2024.2.2]
-pytest-asyncio==0.23.6
-└── pytest [required: >=7.0.0,<9, installed: 8.2.0]
+└── certifi [required: Any, installed: 2024.6.2]
+pytest-asyncio==0.23.7
+└── pytest [required: >=7.0.0,<9, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
-pytest-retry==1.6.2
-└── pytest [required: >=7.0.0, installed: 8.2.0]
+pytest-retry==1.6.3
+└── pytest [required: >=7.0.0, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 pytest-xdist==3.6.1
 ├── execnet [required: >=2.1, installed: 2.1.1]
-└── pytest [required: >=7.0.0, installed: 8.2.0]
+└── pytest [required: >=7.0.0, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -6,17 +6,16 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
-ed25519==1.5
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 nats-py==2.7.2
-nkeys==0.1.0
+nkeys==0.2.0
 oms-mqclient==2.4.10
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -24,19 +23,18 @@ wipac-dev-tools==1.9.1
 ########################################################################
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 nats-py==2.7.2
-nkeys==0.1.0
-└── ed25519 [required: Any, installed: 1.5]
-pipdeptree==2.19.1
+nkeys==0.2.0
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -6,15 +6,15 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 oms-mqclient==2.4.10
 pulsar-client==3.1.0
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -22,19 +22,19 @@ wipac-dev-tools==1.9.1
 ########################################################################
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
-pipdeptree==2.19.1
+        └── typing_extensions [required: Any, installed: 4.12.1]
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 pulsar-client==3.1.0
-└── certifi [required: Any, installed: 2024.2.2]
+└── certifi [required: Any, installed: 2024.6.2]
 setuptools==65.5.1
 wheel==0.43.0

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -6,15 +6,15 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 oms-mqclient==2.4.10
 pika==1.3.2
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -22,17 +22,17 @@ wipac-dev-tools==1.9.1
 ########################################################################
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
+        └── typing_extensions [required: Any, installed: 4.12.1]
 pika==1.3.2
-pipdeptree==2.19.1
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -7,22 +7,22 @@
 #  pip freeze
 ########################################################################
 asyncstdlib==3.12.3
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
 execnet==2.1.1
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 iniconfig==2.0.0
 oms-mqclient==2.4.10
 packaging==24.0
 pluggy==1.5.0
-pytest==8.2.0
-pytest-asyncio==0.23.6
-pytest-retry==1.6.2
+pytest==8.2.1
+pytest-asyncio==0.23.7
+pytest-retry==1.6.3
 pytest-xdist==3.6.1
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -31,31 +31,31 @@ wipac-dev-tools==1.9.1
 asyncstdlib==3.12.3
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
-pipdeptree==2.19.1
+        └── typing_extensions [required: Any, installed: 4.12.1]
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
-pytest-asyncio==0.23.6
-└── pytest [required: >=7.0.0,<9, installed: 8.2.0]
+pytest-asyncio==0.23.7
+└── pytest [required: >=7.0.0,<9, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
-pytest-retry==1.6.2
-└── pytest [required: >=7.0.0, installed: 8.2.0]
+pytest-retry==1.6.3
+└── pytest [required: >=7.0.0, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]
 pytest-xdist==3.6.1
 ├── execnet [required: >=2.1, installed: 2.1.1]
-└── pytest [required: >=7.0.0, installed: 8.2.0]
+└── pytest [required: >=7.0.0, installed: 8.2.1]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.0]
     └── pluggy [required: >=1.5,<2.0, installed: 1.5.0]

--- a/dependencies.log
+++ b/dependencies.log
@@ -6,14 +6,14 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-certifi==2024.2.2
+certifi==2024.6.2
 charset-normalizer==3.3.2
 htchirp==3.0
-htcondor==23.6.1
+htcondor==23.7.2
 idna==3.7
 oms-mqclient==2.4.10
-requests==2.31.0
-typing_extensions==4.11.0
+requests==2.32.3
+typing_extensions==4.12.1
 urllib3==2.2.1
 wipac-dev-tools==1.9.1
 ########################################################################
@@ -21,16 +21,16 @@ wipac-dev-tools==1.9.1
 ########################################################################
 ewms-pilot
 ├── htchirp [required: Any, installed: 3.0]
-├── htcondor [required: Any, installed: 23.6.1]
+├── htcondor [required: Any, installed: 23.7.2]
 └── oms-mqclient [required: Any, installed: 2.4.10]
     └── wipac-dev-tools [required: Any, installed: 1.9.1]
-        ├── requests [required: Any, installed: 2.31.0]
-        │   ├── certifi [required: >=2017.4.17, installed: 2024.2.2]
+        ├── requests [required: Any, installed: 2.32.3]
+        │   ├── certifi [required: >=2017.4.17, installed: 2024.6.2]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
         │   ├── idna [required: >=2.5,<4, installed: 3.7]
         │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.1]
-        └── typing_extensions [required: Any, installed: 4.11.0]
-pipdeptree==2.19.1
+        └── typing_extensions [required: Any, installed: 4.12.1]
+pipdeptree==2.22.0
 ├── packaging [required: >=23.1, installed: 24.0]
 └── pip [required: >=23.1.2, installed: 24.0]
 setuptools==65.5.1

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -80,6 +80,8 @@ async def consume_and_reply(
     chirper = htchirp_tools.Chirper()
     chirper.initial_chirp()
 
+    queue_incoming = queue_incoming.split(";")[0]  # TODO: multi-input (w/ switch)
+    queue_outgoing = queue_outgoing.split(";")[0]  # ''
     if not queue_incoming or not queue_outgoing:
         raise RuntimeError("Must define an incoming and an outgoing queue")
 


### PR DESCRIPTION
No functionality change. Will allow given queues (provided by env vars) to be split by `;`, which in a future PR, will allow for using multiple input/output queues.