### PR TITLE
Require: Broker Info for Each Queue, Use of Env Vars [minor]

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -174,7 +174,7 @@ jobs:
           import mqclient as mq
           import os, asyncio
           queue = mq.Queue(
-              os.environ["EWMS_PILOT_BROKER_CLIENT"],
+              os.environ["EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE"],
               address=os.environ["EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS"],
               name="b345",
           )
@@ -241,7 +241,8 @@ jobs:
           echo "running tests..."
 
           pip install --upgrade pip wheel setuptools pytest
-          export EWMS_PILOT_BROKER_CLIENT=${{ matrix.broker_client }}
+          export EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE=${{ matrix.broker_client }}
+          export EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE=${{ matrix.broker_client }}
           pip install .[test,${{ matrix.broker_client }}]
 
           if [ "${{ matrix.broker_client }}" = "pulsar" ]; then

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -9,9 +9,13 @@ concurrency:
 
 env:
   PULSAR_CONTAINER: pulsar_local
-  EWMS_PILOT_BROKER_ADDRESS: localhost
+  #
+  EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS: localhost
   EWMS_PILOT_TIMEOUT_INCOMING: 1
+  #
+  EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS: localhost
   EWMS_PILOT_TIMEOUT_OUTGOING: 1
+  #
   DOCKER_IMAGE_NAME: pilot-test/example
 
 
@@ -157,19 +161,21 @@ jobs:
           echo "running examples..."
 
           pip install --upgrade pip wheel setuptools pytest
-          export EWMS_PILOT_BROKER_CLIENT=${{ matrix.broker_client }}
+          export EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE=${{ matrix.broker_client }}
+          export EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE=${{ matrix.broker_client }}
           pip install .[test,${{ matrix.broker_client }}]
 
           export EWMS_PILOT_QUEUE_INCOMING="a012"
           export EWMS_PILOT_QUEUE_OUTGOING="b345"
           python examples/do_task.py
 
+          # read messages
           out=$(python -c '
           import mqclient as mq
           import os, asyncio
           queue = mq.Queue(
               os.environ["EWMS_PILOT_BROKER_CLIENT"],
-              address=os.environ["EWMS_PILOT_BROKER_ADDRESS"],
+              address=os.environ["EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS"],
               name="b345",
           )
           async def go():

--- a/dependencies-all.log
+++ b/dependencies-all.log
@@ -43,7 +43,7 @@ nkeys==0.2.0
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.6.2]
 setuptools==70.0.0

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -53,7 +53,7 @@ nkeys==0.2.0
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.6.2]
 pytest-asyncio==0.23.7

--- a/dependencies-nats.log
+++ b/dependencies-nats.log
@@ -40,6 +40,6 @@ nats-py==2.7.2
 nkeys==0.2.0
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 setuptools==70.0.0
 wheel==0.43.0

--- a/dependencies-pulsar.log
+++ b/dependencies-pulsar.log
@@ -37,7 +37,7 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.6.2]
 setuptools==70.0.0

--- a/dependencies-rabbitmq.log
+++ b/dependencies-rabbitmq.log
@@ -38,6 +38,6 @@ ewms-pilot
 pika==1.3.2
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 setuptools==70.0.0
 wheel==0.43.0

--- a/dependencies-test.log
+++ b/dependencies-test.log
@@ -46,7 +46,7 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 pytest-asyncio==0.23.7
 └── pytest [required: >=7.0.0,<9, installed: 8.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]

--- a/dependencies.log
+++ b/dependencies.log
@@ -36,6 +36,6 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 pipdeptree==2.23.0
 ├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.0]
+└── pip [required: >=23.1.2, installed: 24.1]
 setuptools==70.0.0
 wheel==0.43.0

--- a/ewms_pilot/__main__.py
+++ b/ewms_pilot/__main__.py
@@ -5,7 +5,7 @@ import asyncio
 
 from wipac_dev_tools import argparse_tools, logging_tools
 
-from .config import ENV, LOGGER
+from .config import LOGGER
 from .pilot import consume_and_reply
 
 
@@ -37,93 +37,8 @@ def main() -> None:
         default="",
         help="the init command run once before processing any tasks",
     )
-    parser.add_argument(
-        "--multitasking",
-        type=int,
-        default=ENV.EWMS_PILOT_CONCURRENT_TASKS,
-        help="the max number of tasks to process in parallel",
-    )
-
-    # mq args
-    parser.add_argument(
-        "--queue-incoming",
-        required=True,
-        help="the name of the incoming queue",
-    )
-    parser.add_argument(
-        "--queue-outgoing",
-        required=True,
-        help="the name of the outgoing queue",
-    )
-    parser.add_argument(
-        "--broker-client",
-        default=ENV.EWMS_PILOT_BROKER_CLIENT,
-        help="which kind of broker: pulsar, rabbitmq, etc.",
-    )
-    parser.add_argument(
-        "-b",
-        "--broker",
-        default=ENV.EWMS_PILOT_BROKER_ADDRESS,
-        help="The MQ broker URL to connect to",
-    )
-    parser.add_argument(
-        "--prefetch",
-        default=ENV.EWMS_PILOT_PREFETCH,
-        type=int,
-        help="prefetch for incoming messages",
-    )
-    parser.add_argument(
-        "--timeout-wait-for-first-message",
-        default=ENV.EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE,
-        type=int,
-        help="timeout (seconds) for the first message to arrive at the pilot; "
-        "defaults to `--timeout-incoming` value",
-    )
-    parser.add_argument(
-        "--timeout-incoming",
-        default=ENV.EWMS_PILOT_TIMEOUT_QUEUE_INCOMING,
-        type=int,
-        help="timeout (seconds) for messages TO pilot",
-    )
-
-    # meta timeouts
-    parser.add_argument(
-        "--init-timeout",
-        default=ENV.EWMS_PILOT_INIT_TIMEOUT,
-        type=int,
-        help="timeout (seconds) for the init command",
-    )
-    parser.add_argument(
-        "--task-timeout",
-        default=ENV.EWMS_PILOT_TASK_TIMEOUT,
-        type=int,
-        help="timeout (seconds) for each task",
-    )
-    parser.add_argument(
-        "--quarantine-time",
-        default=ENV.EWMS_PILOT_QUARANTINE_TIME,
-        type=int,
-        help="amount of time to sleep after error (useful for preventing blackhole scenarios on condor)",
-    )
 
     # logging/debugging args
-    parser.add_argument(
-        "-l",
-        "--log",
-        default=ENV.EWMS_PILOT_CL_LOG,
-        help="the output logging level (for first-party loggers)",
-    )
-    parser.add_argument(
-        "--log-third-party",
-        default=ENV.EWMS_PILOT_CL_LOG_THIRD_PARTY,
-        help="the output logging level for third-party loggers",
-    )
-    parser.add_argument(
-        "--dump-task-output",
-        default=ENV.EWMS_PILOT_DUMP_TASK_OUTPUT,
-        action="store_true",
-        help="dump each task's stderr to stderr and stdout to stdout",
-    )
     parser.add_argument(
         "--debug-directory",
         default="",
@@ -148,21 +63,6 @@ def main() -> None:
     asyncio.run(
         consume_and_reply(
             cmd=args.cmd,
-            task_timeout=args.task_timeout,
-            multitasking=args.multitasking,
-            #
-            # mq broker
-            broker_client=args.broker_client,
-            broker_address=args.broker,
-            #
-            # incoming
-            queue_incoming=args.queue_incoming,
-            prefetch=args.prefetch,
-            timeout_wait_for_first_message=args.timeout_wait_for_first_message,
-            timeout_incoming=args.timeout_incoming,
-            #
-            # outgoing
-            queue_outgoing=args.queue_outgoing,
             #
             # to subprocess
             infile_type=args.infile_type,
@@ -170,12 +70,9 @@ def main() -> None:
             #
             # init
             init_cmd=args.init_cmd,
-            init_timeout=args.init_timeout,
             #
             # misc settings
             debug_dir=args.debug_directory,
-            dump_task_output=args.dump_task_output,
-            quarantine_time=args.quarantine_time,
         )
     )
     LOGGER.info("Done.")

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -25,15 +25,25 @@ class EnvConfig:
     # broker -- assumes one broker is the norm
     EWMS_PILOT_BROKER_CLIENT: str = "rabbitmq"
     EWMS_PILOT_BROKER_ADDRESS: str = "localhost"
-    EWMS_PILOT_QUEUE_INCOMING: str = ""
+    #
+    EWMS_PILOT_QUEUE_INCOMING: str = ""  # name of the incoming queue
     EWMS_PILOT_QUEUE_INCOMING_AUTH_TOKEN: str = ""
-    EWMS_PILOT_QUEUE_OUTGOING: str = ""
+    # which kind of broker: pulsar, rabbitmq, etc.
+    # MQ broker URL to connect to
+    #
+    EWMS_PILOT_QUEUE_OUTGOING: str = ""  # name of the outgoing queue
     EWMS_PILOT_QUEUE_OUTGOING_AUTH_TOKEN: str = ""
+    # which kind of broker: pulsar, rabbitmq, etc.
+    # MQ broker URL to connect to
 
-    # logging
-    EWMS_PILOT_CL_LOG: str = "INFO"  # only used when running via command line
-    EWMS_PILOT_CL_LOG_THIRD_PARTY: str = "WARNING"  # ^^^
-    EWMS_PILOT_DUMP_TASK_OUTPUT: bool = False
+    # logging -- only used when running via command line
+    EWMS_PILOT_CL_LOG: str = "INFO"  # level for 1st-party loggers
+    EWMS_PILOT_CL_LOG_THIRD_PARTY: str = "WARNING"  # level for 3rd-party loggers
+
+    # dumping
+    EWMS_PILOT_DUMP_TASK_OUTPUT: bool = (
+        False  # dump each task's stderr to stderr and stdout to stdout
+    )
 
     # chirp
     EWMS_PILOT_HTCHIRP: bool = False
@@ -41,17 +51,29 @@ class EnvConfig:
     EWMS_PILOT_HTCHIRP_RATELIMIT_INTERVAL: float = 60.0
 
     # timing config -- queues
-    EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE: Optional[int] = None
-    EWMS_PILOT_TIMEOUT_QUEUE_INCOMING: int = 1
+    EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE: Optional[int] = (
+        None  # timeout (sec) for the first message to arrive at the pilot (defaults to incoming timeout value)
+    )
+    EWMS_PILOT_TIMEOUT_QUEUE_INCOMING: int = 1  # timeout (sec) for messages TO pilot
+
     # timing config -- tasks
-    EWMS_PILOT_INIT_TIMEOUT: Optional[int] = None
-    EWMS_PILOT_TASK_TIMEOUT: Optional[int] = None
-    EWMS_PILOT_QUARANTINE_TIME: int = 0  # seconds
+    EWMS_PILOT_INIT_TIMEOUT: Optional[int] = None  # timeout (sec) for the init command
+    EWMS_PILOT_TASK_TIMEOUT: Optional[int] = None  # timeout (sec) for each task
+    EWMS_PILOT_QUARANTINE_TIME: int = (
+        0  # how long to sleep after error (useful for preventing blackhole scenarios on condor)
+    )
 
     # task handling logic
-    EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR: bool = True
-    EWMS_PILOT_CONCURRENT_TASKS: int = 1
-    EWMS_PILOT_PREFETCH: int = 1  # off by default -- prefetch is an optimization
+    EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR: bool = (
+        True
+        # whether to stop taking future tasks after a task fails;
+        # ex: set to False if on known good compute node (testing cluster),
+        #     set to True  if on unknown node (large hemogenous cluster)
+    )
+    EWMS_PILOT_CONCURRENT_TASKS: int = 1  # max number of tasks to process in parallel
+    EWMS_PILOT_PREFETCH: int = (
+        1  # prefetch amount for incoming messages (off by default -- prefetch is an optimization)
+    )
 
     def __post_init__(self) -> None:
         if timeout := os.getenv("EWMS_PILOT_SUBPROC_TIMEOUT"):

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -2,6 +2,10 @@
 
 import dataclasses as dc
 import logging
+import os
+from typing import Optional
+
+from wipac_dev_tools import from_environment_as_dataclass
 
 LOGGER = logging.getLogger("ewms-pilot")
 
@@ -24,6 +28,15 @@ class EnvConfig:
     EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE: str = ""  # broker type: pulsar, rabbitmq...
     EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS: str = ""  # MQ broker URL to connect to
 
+    # incoming queue - settings
+    EWMS_PILOT_PREFETCH: int = (
+        1  # prefetch amount for incoming messages (off by default -- prefetch is an optimization)
+    )
+    EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE: Optional[int] = (
+        None  # timeout (sec) for the first message to arrive at the pilot (defaults to incoming timeout value)
+    )
+    EWMS_PILOT_TIMEOUT_QUEUE_INCOMING: int = 1  # timeout (sec) for messages TO pilot
+
     # outgoing queue
     EWMS_PILOT_QUEUE_OUTGOING: str = ""  # name of the outgoing queue
     EWMS_PILOT_QUEUE_OUTGOING_AUTH_TOKEN: str = ""  # auth token for queue
@@ -34,28 +47,14 @@ class EnvConfig:
     EWMS_PILOT_CL_LOG: str = "INFO"  # level for 1st-party loggers
     EWMS_PILOT_CL_LOG_THIRD_PARTY: str = "WARNING"  # level for 3rd-party loggers
 
-    # dumping
-    EWMS_PILOT_DUMP_TASK_OUTPUT: bool = (
-        False  # dump each task's stderr to stderr and stdout to stdout
-    )
-
     # chirp
     EWMS_PILOT_HTCHIRP: bool = False
     EWMS_PILOT_HTCHIRP_DEST: str = "JOB_ATTR"  # ["JOB_EVENT_LOG", "JOB_ATTR"]
     EWMS_PILOT_HTCHIRP_RATELIMIT_INTERVAL: float = 60.0
 
-    # timing config -- queues
-    EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE: Optional[int] = (
-        None  # timeout (sec) for the first message to arrive at the pilot (defaults to incoming timeout value)
-    )
-    EWMS_PILOT_TIMEOUT_QUEUE_INCOMING: int = 1  # timeout (sec) for messages TO pilot
-
     # timing config -- tasks
     EWMS_PILOT_INIT_TIMEOUT: Optional[int] = None  # timeout (sec) for the init command
     EWMS_PILOT_TASK_TIMEOUT: Optional[int] = None  # timeout (sec) for each task
-    EWMS_PILOT_QUARANTINE_TIME: int = (
-        0  # how long to sleep after error (useful for preventing blackhole scenarios on condor)
-    )
 
     # task handling logic
     EWMS_PILOT_STOP_LISTENING_ON_TASK_ERROR: bool = (
@@ -65,8 +64,13 @@ class EnvConfig:
         #     set to True  if on unknown node (large hemogenous cluster)
     )
     EWMS_PILOT_CONCURRENT_TASKS: int = 1  # max number of tasks to process in parallel
-    EWMS_PILOT_PREFETCH: int = (
-        1  # prefetch amount for incoming messages (off by default -- prefetch is an optimization)
+
+    # misc settings
+    EWMS_PILOT_DUMP_TASK_OUTPUT: bool = (
+        False  # dump each task's stderr to stderr and stdout to stdout
+    )
+    EWMS_PILOT_QUARANTINE_TIME: int = (
+        0  # how long to sleep after error (useful for preventing blackhole scenarios on condor)
     )
 
     def __post_init__(self) -> None:

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -61,9 +61,9 @@ class EnvConfig:
         True
         # whether to stop taking future tasks after a task fails;
         # ex: set to False if on known good compute node (testing cluster),
-        #     set to True  if on unknown node (large hemogenous cluster)
+        #     set to True  if on unknown node (large homogeneous cluster)
     )
-    EWMS_PILOT_CONCURRENT_TASKS: int = 1  # max number of tasks to process in parallel
+    EWMS_PILOT_MAX_CONCURRENT_TASKS: int = 1  # max no. of tasks to process in parallel
 
     # misc settings
     EWMS_PILOT_DUMP_TASK_OUTPUT: bool = (
@@ -86,9 +86,9 @@ class EnvConfig:
                 # b/c frozen
                 object.__setattr__(self, "EWMS_PILOT_TASK_TIMEOUT", int(timeout))
 
-        if self.EWMS_PILOT_CONCURRENT_TASKS < 1:
+        if self.EWMS_PILOT_MAX_CONCURRENT_TASKS < 1:
             LOGGER.warning(
-                f"Invalid value for 'EWMS_PILOT_CONCURRENT_TASKS' ({self.EWMS_PILOT_CONCURRENT_TASKS}),"
+                f"Invalid value for 'EWMS_PILOT_MAX_CONCURRENT_TASKS' ({self.EWMS_PILOT_MAX_CONCURRENT_TASKS}),"
                 " defaulting to '1'."
             )
             object.__setattr__(self, "EWMS_PILOT_CONCURRENT_TASKS", 1)  # b/c frozen

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -2,10 +2,6 @@
 
 import dataclasses as dc
 import logging
-import os
-from typing import Optional
-
-from wipac_dev_tools import from_environment_as_dataclass
 
 LOGGER = logging.getLogger("ewms-pilot")
 
@@ -22,19 +18,17 @@ REFRESH_INTERVAL = 1  # sec -- the time between transitioning phases of the main
 class EnvConfig:
     """For storing environment variables, typed."""
 
-    # broker -- assumes one broker is the norm
-    EWMS_PILOT_BROKER_CLIENT: str = "rabbitmq"
-    EWMS_PILOT_BROKER_ADDRESS: str = "localhost"
-    #
+    # incoming queue
     EWMS_PILOT_QUEUE_INCOMING: str = ""  # name of the incoming queue
-    EWMS_PILOT_QUEUE_INCOMING_AUTH_TOKEN: str = ""
-    # which kind of broker: pulsar, rabbitmq, etc.
-    # MQ broker URL to connect to
-    #
+    EWMS_PILOT_QUEUE_INCOMING_AUTH_TOKEN: str = ""  # auth token for queue
+    EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE: str = ""  # broker type: pulsar, rabbitmq...
+    EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS: str = ""  # MQ broker URL to connect to
+
+    # outgoing queue
     EWMS_PILOT_QUEUE_OUTGOING: str = ""  # name of the outgoing queue
-    EWMS_PILOT_QUEUE_OUTGOING_AUTH_TOKEN: str = ""
-    # which kind of broker: pulsar, rabbitmq, etc.
-    # MQ broker URL to connect to
+    EWMS_PILOT_QUEUE_OUTGOING_AUTH_TOKEN: str = ""  # auth token for queue
+    EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE: str = ""  # broker type: pulsar, rabbitmq...
+    EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS: str = ""  # MQ broker URL to connect to
 
     # logging -- only used when running via command line
     EWMS_PILOT_CL_LOG: str = "INFO"  # level for 1st-party loggers

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -38,7 +38,7 @@ _EXCEPT_ERRORS = False
 async def consume_and_reply(
     cmd: str,
     task_timeout: Optional[int] = ENV.EWMS_PILOT_TASK_TIMEOUT,
-    multitasking: int = ENV.EWMS_PILOT_CONCURRENT_TASKS,
+    max_concurrent_tasks: int = ENV.EWMS_PILOT_MAX_CONCURRENT_TASKS,
     #
     # incoming queue
     queue_incoming: str = ENV.EWMS_PILOT_QUEUE_INCOMING,
@@ -132,7 +132,7 @@ async def consume_and_reply(
             dump_task_output,
             #
             task_timeout,
-            multitasking,
+            max_concurrent_tasks,
             #
             housekeeper,
         )
@@ -240,7 +240,7 @@ async def _consume_and_reply(
     dump_task_output: bool,
     #
     task_timeout: Optional[int],
-    multitasking: int,
+    max_concurrent_tasks: int,
     #
     housekeeper: Housekeeping,
 ) -> None:
@@ -278,7 +278,7 @@ async def _consume_and_reply(
     #
     # open pub & sub
     async with out_queue.open_pub() as pub, in_queue.open_sub_manual_acking() as sub:
-        LOGGER.info(f"Processing up to {multitasking} tasks concurrently")
+        LOGGER.info(f"Processing up to {max_concurrent_tasks} tasks concurrently")
         message_iterator = sub.iter_messages()
         await housekeeper.entered_listener_loop()
         #
@@ -292,7 +292,7 @@ async def _consume_and_reply(
             await housekeeper.queue_housekeeping(in_queue, sub, pub)
             #
             # get messages/tasks
-            if len(pending) >= multitasking:
+            if len(pending) >= max_concurrent_tasks:
                 LOGGER.debug("At max task concurrency limit")
             else:
                 LOGGER.debug("Listening for incoming message...")

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -40,22 +40,23 @@ async def consume_and_reply(
     task_timeout: Optional[int] = ENV.EWMS_PILOT_TASK_TIMEOUT,
     multitasking: int = ENV.EWMS_PILOT_CONCURRENT_TASKS,
     #
-    # mq broker
-    broker_client: str = ENV.EWMS_PILOT_BROKER_CLIENT,
-    broker_address: str = ENV.EWMS_PILOT_BROKER_ADDRESS,
-    #
-    # incoming
+    # incoming queue
     queue_incoming: str = ENV.EWMS_PILOT_QUEUE_INCOMING,
     queue_incoming_auth_token: str = ENV.EWMS_PILOT_QUEUE_INCOMING_AUTH_TOKEN,
+    queue_incoming_broker_type: str = ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE,
+    queue_incoming_broker_address: str = ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS,
+    # incoming queue - settings
     prefetch: int = ENV.EWMS_PILOT_PREFETCH,
     timeout_wait_for_first_message: Optional[
         int
     ] = ENV.EWMS_PILOT_TIMEOUT_QUEUE_WAIT_FOR_FIRST_MESSAGE,
     timeout_incoming: int = ENV.EWMS_PILOT_TIMEOUT_QUEUE_INCOMING,
     #
-    # outgoing
+    # outgoing queue
     queue_outgoing: str = ENV.EWMS_PILOT_QUEUE_OUTGOING,
     queue_outgoing_auth_token: str = ENV.EWMS_PILOT_QUEUE_OUTGOING_AUTH_TOKEN,
+    queue_outgoing_broker_type: str = ENV.EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE,
+    queue_outgoing_broker_address: str = ENV.EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS,
     #
     # for subprocess
     infile_type: str = ".in",
@@ -98,8 +99,8 @@ async def consume_and_reply(
 
         # connect queues
         in_queue = mq.Queue(
-            broker_client,
-            address=broker_address,
+            queue_incoming_broker_type,
+            address=queue_incoming_broker_address,
             name=queue_incoming,
             prefetch=prefetch,
             auth_token=queue_incoming_auth_token,
@@ -107,8 +108,8 @@ async def consume_and_reply(
             # timeout=timeout_incoming, # manually set below
         )
         out_queue = mq.Queue(
-            broker_client,
-            address=broker_address,
+            queue_outgoing_broker_type,
+            address=queue_outgoing_broker_address,
             name=queue_outgoing,
             auth_token=queue_outgoing_auth_token,
             except_errors=_EXCEPT_ERRORS,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -79,8 +79,8 @@ async def populate_queue(
 ) -> None:
     """Send messages to queue."""
     to_client_q = mq.Queue(
-        config.ENV.EWMS_PILOT_BROKER_CLIENT,
-        address=config.ENV.EWMS_PILOT_BROKER_ADDRESS,
+        config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE,
+        address=config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS,
         name=queue_incoming,
     )
 
@@ -101,8 +101,8 @@ async def assert_results(
 ) -> None:
     """Get messages and assert against expected results."""
     from_client_q = mq.Queue(
-        config.ENV.EWMS_PILOT_BROKER_CLIENT,
-        address=config.ENV.EWMS_PILOT_BROKER_ADDRESS,
+        config.ENV.EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE,
+        address=config.ENV.EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS,
         name=queue_outgoing,
     )
     received: list = []
@@ -688,7 +688,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 @pytest.mark.flaky(  # https://pypi.org/project/pytest-retry/
     retries=3,
     delay=1,
-    condition=config.ENV.EWMS_PILOT_BROKER_CLIENT == "rabbitmq",
+    condition=config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE == "rabbitmq",
 )
 @pytest.mark.usefixtures("unique_pwd")
 @pytest.mark.parametrize("use_debug_dir", [True, False])
@@ -726,7 +726,8 @@ async def test_510__concurrent_load_max_concurrent_tasks_exceptions(
                     if not (
                         prefetch == 1
                         and not use_debug_dir
-                        and config.ENV.EWMS_PILOT_BROKER_CLIENT == "rabbitmq"
+                        and config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE
+                        == "rabbitmq"
                     )
                     else 0
                 ),
@@ -930,7 +931,7 @@ async def test_1000__rabbitmq_heartbeat_workaround(
     refresh_interval_rabbitmq_heartbeat_interval: float,
 ) -> None:
     """Test a normal .txt-based pilot."""
-    if config.ENV.EWMS_PILOT_BROKER_CLIENT != "rabbitmq":
+    if config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE != "rabbitmq":
         return
 
     msgs_to_subproc = MSGS_TO_SUBPROC[:2]


### PR DESCRIPTION
- Separates broker address and type from 1-per-client to 1-per-queue
   + added env vars: `EWMS_PILOT_QUEUE_INCOMING_BROKER_ADDRESS`, `EWMS_PILOT_QUEUE_OUTGOING_BROKER_ADDRESS`, `EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE`, `EWMS_PILOT_QUEUE_OUTGOING_BROKER_TYPE` (and related func params)
	+ removed `EWMS_PILOT_BROKER_ADDRESS` and `EWMS_PILOT_BROKER_CLIENT` (and related func params)
   + allows flexibility for future dev
   + driven by updates seen in https://github.com/Observation-Management-Service/ewms-workflow-management-service/pull/34
- Removes many CL args that were redundant with existing env vars
   + makes updates much easier
- Refactors `multitasking` to `max_concurrent_tasks` (`EWMS_PILOT_MAX_CONCURRENT_TASKS`)
   + "multi-tasking" in the EWMS lexicon can be confused with multi-task workflows