### PR TITLE
Add Env Var for Setting Pilot Root Dir on Host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,9 @@ WORKDIR /app
 # given by condor when run via singularity / apptainer
 ENV SINGULARITY_TARGET_DIR=""
 # overridable -- and by default, it's "" (aka the root dir)
-ENV EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST="$SINGULARITY_TARGET_DIR"
-RUN mkdir -p "$EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST/ewms-pilot/"
-RUN mkdir -p "$EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST/ewms-pilot/store"
+ENV EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST="$SINGULARITY_TARGET_DIR"
+RUN mkdir -p "$EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST/ewms-pilot-data/"
+RUN mkdir -p "$EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST/ewms-pilot-data/data-hub"
 
 # entrypoint magic
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,13 @@ RUN mkdir /app
 WORKDIR /app
 #
 # the directory exposed to all tasks
-RUN mkdir -p /ewms-pilot/
-RUN chmod -R 777 /ewms-pilot/
 #
-RUN mkdir -p /ewms-pilot/store
+# given by condor when run via singularity / apptainer
+ENV SINGULARITY_TARGET_DIR=""
+# overridable -- and by default, it's "" (aka the root dir)
+ENV EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST="$SINGULARITY_TARGET_DIR"
+RUN mkdir -p "$EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST/ewms-pilot/"
+RUN mkdir -p "$EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST/ewms-pilot/store"
 
 # entrypoint magic
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,12 @@ echo ""
 echo "Setting up the EWMS Task Pilot Container Environment..."
 
 # inspect the file system
-chmod -R 777 /ewms-pilot/
 echo "----"
 echo "$PWD"
-ls -ld $PWD/*
-ls -ld /ewms-pilot/*
+ls -l $PWD
+echo "----"
+echo "$EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST"
+ls -lR $EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST  # recursive
 
 echo "----"
 echo "Activating docker daemon..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,8 @@ echo "Setting up the EWMS Task Pilot Container Environment..."
 # inspect the file system
 chmod -R 777 /ewms-pilot/
 echo "----"
+echo "$PWD"
 ls -ld $PWD/*
-echo "----"
-ls -ld /*
-echo "----"
 ls -ld /ewms-pilot/*
 
 echo "----"

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -52,7 +52,7 @@ class EnvConfig:
     # OPTIONAL
     #
 
-    EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST: str = ""
+    EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST: str = ""
 
     # I/O to subprocess -- the file type (extension) of the input/output file from the pilot's task
     EWMS_PILOT_INFILE_TYPE: str = ".in"  # ''
@@ -145,10 +145,10 @@ ENV = from_environment_as_dataclass(EnvConfig)
 #
 
 
-PILOT_ROOT_DIR = Path(
-    f"{ENV.EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST.rstrip('/')}/ewms-pilot"
+PILOT_DATA_DIR = Path(
+    f"{ENV.EWMS_PILOT_DATA_DIR_PARENT_PATH_ON_HOST.rstrip('/')}/ewms-pilot-data"
 )
-PILOT_STORE_DIR = PILOT_ROOT_DIR / "store"
+PILOT_DATA_HUB_DIR = PILOT_DATA_DIR / "data-hub"
 
 
 class DirectoryCatalog:
@@ -161,12 +161,12 @@ class DirectoryCatalog:
 
     def __init__(self, name: str):
         """Directories are not pre-created; you must `mkdir -p` to use."""
-        self._namebased_dir = PILOT_ROOT_DIR / name
+        self._namebased_dir = PILOT_DATA_DIR / name
 
         # for inter-task/init storage: startup data, init container's output, etc.
-        self.pilot_store = self._ContainerBindMountDirPair(
-            PILOT_STORE_DIR,
-            PILOT_STORE_DIR,
+        self.pilot_data_hub = self._ContainerBindMountDirPair(
+            PILOT_DATA_HUB_DIR,
+            PILOT_DATA_HUB_DIR,
         )
 
         # for persisting stderr and stdout
@@ -175,7 +175,7 @@ class DirectoryCatalog:
         # for message-based task i/o
         self.task_io = self._ContainerBindMountDirPair(
             self._namebased_dir / "task-io",
-            PILOT_ROOT_DIR / "task-io",
+            PILOT_DATA_DIR / "task-io",
         )
 
     def assemble_bind_mounts(
@@ -184,7 +184,7 @@ class DirectoryCatalog:
         task_io: bool = False,
     ) -> str:
         """Get the docker bind mount string containing the wanted directories."""
-        string = f"--mount type=bind,source={self.pilot_store.on_host},target={self.pilot_store.in_container} "
+        string = f"--mount type=bind,source={self.pilot_data_hub.on_host},target={self.pilot_data_hub.in_container} "
 
         if external_directories:
             string += "".join(

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -150,6 +150,8 @@ PILOT_DATA_DIR = Path(
 )
 PILOT_DATA_HUB_DIR = PILOT_DATA_DIR / "data-hub"
 
+INCONTAINER_ENVNAME_TASK_DATA_HUB_DIR = "EWMS_TASK_DATA_HUB_DIR"
+
 
 class DirectoryCatalog:
     """Handles the naming and mapping logic for a task's directories."""

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -52,6 +52,8 @@ class EnvConfig:
     # OPTIONAL
     #
 
+    EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST: str = ""
+
     # I/O to subprocess -- the file type (extension) of the input/output file from the pilot's task
     EWMS_PILOT_INFILE_TYPE: str = ".in"  # ''
     EWMS_PILOT_OUTFILE_TYPE: str = ".out"  # ''
@@ -143,8 +145,10 @@ ENV = from_environment_as_dataclass(EnvConfig)
 #
 
 
-PILOT_DIR = Path("/ewms-pilot")
-PILOT_STORAGE_DIR = PILOT_DIR / "store"
+PILOT_ROOT_DIR = Path(
+    f"{ENV.EWMS_PILOT_ROOT_DIR_PARENT_DIR_ON_HOST.rstrip('/')}/ewms-pilot"
+)
+PILOT_STORE_DIR = PILOT_ROOT_DIR / "store"
 
 
 class DirectoryCatalog:
@@ -157,12 +161,12 @@ class DirectoryCatalog:
 
     def __init__(self, name: str):
         """Directories are not pre-created; you must `mkdir -p` to use."""
-        self._namebased_dir = PILOT_DIR / name
+        self._namebased_dir = PILOT_ROOT_DIR / name
 
         # for inter-task/init storage: startup data, init container's output, etc.
         self.pilot_store = self._ContainerBindMountDirPair(
-            PILOT_STORAGE_DIR,
-            PILOT_STORAGE_DIR,
+            PILOT_STORE_DIR,
+            PILOT_STORE_DIR,
         )
 
         # for persisting stderr and stdout
@@ -171,7 +175,7 @@ class DirectoryCatalog:
         # for message-based task i/o
         self.task_io = self._ContainerBindMountDirPair(
             self._namebased_dir / "task-io",
-            PILOT_DIR / "task-io",
+            PILOT_ROOT_DIR / "task-io",
         )
 
     def assemble_bind_mounts(

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -165,7 +165,7 @@ async def run_init_container(
             dirs.outputs_on_host / "stdoutfile",
             dirs.outputs_on_host / "stderrfile",
             dirs.assemble_bind_mounts(external_directories=True),
-            f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_store.in_container}",
+            f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_data_hub.in_container}",
         )
     )
     pending = set([task])

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -165,7 +165,7 @@ async def run_init_container(
             dirs.outputs_on_host / "stdoutfile",
             dirs.outputs_on_host / "stderrfile",
             dirs.assemble_bind_mounts(external_directories=True),
-            f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_data_hub.in_container}",
+            f"--env EWMS_TASK_PILOT_DATA_HUB_DIR={dirs.pilot_data_hub.in_container}",
         )
     )
     pending = set([task])

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -11,6 +11,7 @@ from . import htchirp_tools
 from .config import (
     DirectoryCatalog,
     ENV,
+    INCONTAINER_ENVNAME_TASK_DATA_HUB_DIR,
     LOGGER,
     REFRESH_INTERVAL,
 )
@@ -165,7 +166,7 @@ async def run_init_container(
             dirs.outputs_on_host / "stdoutfile",
             dirs.outputs_on_host / "stderrfile",
             dirs.assemble_bind_mounts(external_directories=True),
-            f"--env EWMS_TASK_PILOT_DATA_HUB_DIR={dirs.pilot_data_hub.in_container}",
+            f"--env {INCONTAINER_ENVNAME_TASK_DATA_HUB_DIR}={dirs.pilot_data_hub.in_container}",
         )
     )
     pending = set([task])

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -55,7 +55,7 @@ async def process_msg_task(
         dirs.outputs_on_host / "stderrfile",
         dirs.outputs_on_host / "stdoutfile",
         dirs.assemble_bind_mounts(external_directories=True, task_io=True),
-        f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_store.in_container}",
+        f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_data_hub.in_container}",
     )
     out_data = OutFileInterface.read(dirs.task_io.on_host / outfile_name)
 

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -9,6 +9,7 @@ from .io import FileExtension, InFileInterface, OutFileInterface
 from ..config import (
     DirectoryCatalog,
     ENV,
+    INCONTAINER_ENVNAME_TASK_DATA_HUB_DIR,
 )
 from ..utils.runner import run_container
 
@@ -55,7 +56,7 @@ async def process_msg_task(
         dirs.outputs_on_host / "stderrfile",
         dirs.outputs_on_host / "stdoutfile",
         dirs.assemble_bind_mounts(external_directories=True, task_io=True),
-        f"--env EWMS_TASK_PILOT_DATA_HUB_DIR={dirs.pilot_data_hub.in_container}",
+        f"--env {INCONTAINER_ENVNAME_TASK_DATA_HUB_DIR}={dirs.pilot_data_hub.in_container}",
     )
     out_data = OutFileInterface.read(dirs.task_io.on_host / outfile_name)
 

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -55,7 +55,7 @@ async def process_msg_task(
         dirs.outputs_on_host / "stderrfile",
         dirs.outputs_on_host / "stdoutfile",
         dirs.assemble_bind_mounts(external_directories=True, task_io=True),
-        f"--env EWMS_TASK_PILOT_STORE_DIR={dirs.pilot_data_hub.in_container}",
+        f"--env EWMS_TASK_PILOT_DATA_HUB_DIR={dirs.pilot_data_hub.in_container}",
     )
     out_data = OutFileInterface.read(dirs.task_io.on_host / outfile_name)
 

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -20,7 +20,7 @@ import mqclient as mq
 import pytest
 
 from ewms_pilot import PilotSubprocessError, config, consume_and_reply
-from ewms_pilot.config import ENV, PILOT_ROOT_DIR, PILOT_STORE_DIR
+from ewms_pilot.config import ENV, PILOT_DATA_DIR, PILOT_DATA_HUB_DIR
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.getLogger("mqclient").setLevel(logging.INFO)
@@ -106,34 +106,36 @@ async def assert_results(
 def assert_pilot_dirs(
     n_tasks: int,
     task_dir_contents: List[str],
-    store_dir_contents: Optional[List[str]] = None,
+    data_hub_dir_contents: Optional[List[str]] = None,
     has_init_cmd_subdir: bool = False,
 ) -> None:
     """Assert the contents of the debug directory."""
-    pprint(list(PILOT_ROOT_DIR.rglob("*")))  # for debugging
+    pprint(list(PILOT_DATA_DIR.rglob("*")))  # for debugging
 
     # validate args
     task_dir_contents = [c.rstrip("/") for c in task_dir_contents]
     assert len(task_dir_contents) == len(set(task_dir_contents))  # no duplicates
     #
-    if not store_dir_contents:
-        store_dir_contents = []
+    if not data_hub_dir_contents:
+        data_hub_dir_contents = []
 
     # check num of dirs
     if has_init_cmd_subdir:
-        assert len(list(PILOT_ROOT_DIR.iterdir())) == n_tasks + 1 + 1  # store/ & init*/
+        assert (
+            len(list(PILOT_DATA_DIR.iterdir())) == n_tasks + 1 + 1
+        )  # data-hub/ & init*/
     else:
-        assert len(list(PILOT_ROOT_DIR.iterdir())) == n_tasks + 1  # store/
+        assert len(list(PILOT_DATA_DIR.iterdir())) == n_tasks + 1  # data-hub/
 
     # check each task's dir contents
-    for subdir in PILOT_ROOT_DIR.iterdir():
+    for subdir in PILOT_DATA_DIR.iterdir():
         assert subdir.is_dir()
 
-        # is this the store subdir?
-        if subdir.name == "store":
+        # is this the data-hub subdir?
+        if subdir.name == "data-hub":
             assert sorted(
                 str(p.relative_to(subdir)) for p in subdir.rglob("*")
-            ) == sorted(store_dir_contents)
+            ) == sorted(data_hub_dir_contents)
             continue
         # is this an init subdir?
         elif has_init_cmd_subdir and subdir.name.startswith("init"):
@@ -957,7 +959,7 @@ with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
     )
 
     # check init's output
-    with open(PILOT_STORE_DIR / "initoutput") as f:
+    with open(PILOT_DATA_HUB_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
     # check task stuff
@@ -1013,7 +1015,7 @@ time.sleep({init_timeout})
         )
 
     # check init's output
-    with open(PILOT_STORE_DIR / "initoutput") as f:
+    with open(PILOT_DATA_HUB_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
 
@@ -1050,7 +1052,7 @@ raise ValueError('no good!')
         )
 
     # check init's output
-    with open(PILOT_STORE_DIR / "initoutput") as f:
+    with open(PILOT_DATA_HUB_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
 
@@ -1094,7 +1096,7 @@ with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
     )
 
     # check init's output
-    with open(PILOT_STORE_DIR / "initoutput") as f:
+    with open(PILOT_DATA_HUB_DIR / "initoutput") as f:
         assert f.read().strip() == "blue"
 
     # check task stuff

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -945,8 +945,8 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image="python:alpine",
             init_args="""python3 -c "
 import os
-os.makedirs(os.getenv('EWMS_TASK_PILOT_STORE_DIR'), exist_ok=True)
-with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
+os.makedirs(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR'), exist_ok=True)
+with open(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR') + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
 " """,
@@ -1000,8 +1000,8 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_args=f"""python3 -c "
 import time
 import os
-os.makedirs(os.getenv('EWMS_TASK_PILOT_STORE_DIR'), exist_ok=True)
-with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
+os.makedirs(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR'), exist_ok=True)
+with open(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR') + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
 time.sleep({init_timeout})
@@ -1038,8 +1038,8 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image="python:alpine",
             init_args="""python3 -c "
 import os
-os.makedirs(os.getenv('EWMS_TASK_PILOT_STORE_DIR'), exist_ok=True)
-with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
+os.makedirs(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR'), exist_ok=True)
+with open(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR') + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
 raise ValueError('no good!')
@@ -1076,14 +1076,14 @@ async def test_2010_init__use_in_task(
             "python:alpine",
             """python3 -c "
 import os
-output = open('{{INFILE}}').read().strip() + open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput').read().strip();
+output = open('{{INFILE}}').read().strip() + open(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR') + '/initoutput').read().strip();
 print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             #
             init_image="python:alpine",
             init_args="""python3 -c "
 import os
-os.makedirs(os.getenv('EWMS_TASK_PILOT_STORE_DIR'), exist_ok=True)
-with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
+os.makedirs(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR'), exist_ok=True)
+with open(os.getenv('EWMS_TASK_PILOT_DATA_HUB_DIR') + '/initoutput', 'w') as f:
     print('writing to a file...')
     print('blue', file=f)
 " """,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -20,7 +20,7 @@ import mqclient as mq
 import pytest
 
 from ewms_pilot import PilotSubprocessError, config, consume_and_reply
-from ewms_pilot.config import ENV, PILOT_DIR, PILOT_STORAGE_DIR
+from ewms_pilot.config import ENV, PILOT_ROOT_DIR, PILOT_STORE_DIR
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.getLogger("mqclient").setLevel(logging.INFO)
@@ -110,7 +110,7 @@ def assert_pilot_dirs(
     has_init_cmd_subdir: bool = False,
 ) -> None:
     """Assert the contents of the debug directory."""
-    pprint(list(PILOT_DIR.rglob("*")))  # for debugging
+    pprint(list(PILOT_ROOT_DIR.rglob("*")))  # for debugging
 
     # validate args
     task_dir_contents = [c.rstrip("/") for c in task_dir_contents]
@@ -121,12 +121,12 @@ def assert_pilot_dirs(
 
     # check num of dirs
     if has_init_cmd_subdir:
-        assert len(list(PILOT_DIR.iterdir())) == n_tasks + 1 + 1  # store/ & init*/
+        assert len(list(PILOT_ROOT_DIR.iterdir())) == n_tasks + 1 + 1  # store/ & init*/
     else:
-        assert len(list(PILOT_DIR.iterdir())) == n_tasks + 1  # store/
+        assert len(list(PILOT_ROOT_DIR.iterdir())) == n_tasks + 1  # store/
 
     # check each task's dir contents
-    for subdir in PILOT_DIR.iterdir():
+    for subdir in PILOT_ROOT_DIR.iterdir():
         assert subdir.is_dir()
 
         # is this the store subdir?
@@ -854,12 +854,15 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
         )
 
     # run producer & consumer concurrently
-    with patch(
-        "ewms_pilot.pilot.REFRESH_INTERVAL",  # patch at 'ewms_pilot.pilot' bc using from-import
-        refresh_interval_rabbitmq_heartbeat_interval,
-    ), patch(
-        "ewms_pilot.housekeeping.Housekeeping.RABBITMQ_HEARTBEAT_INTERVAL",
-        refresh_interval_rabbitmq_heartbeat_interval,
+    with (
+        patch(
+            "ewms_pilot.pilot.REFRESH_INTERVAL",  # patch at 'ewms_pilot.pilot' bc using from-import
+            refresh_interval_rabbitmq_heartbeat_interval,
+        ),
+        patch(
+            "ewms_pilot.housekeeping.Housekeeping.RABBITMQ_HEARTBEAT_INTERVAL",
+            refresh_interval_rabbitmq_heartbeat_interval,
+        ),
     ):
         if refresh_interval_rabbitmq_heartbeat_interval > TEST_1000_SLEEP:
             with pytest.raises(
@@ -954,7 +957,7 @@ with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
     )
 
     # check init's output
-    with open(PILOT_STORAGE_DIR / "initoutput") as f:
+    with open(PILOT_STORE_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
     # check task stuff
@@ -1010,7 +1013,7 @@ time.sleep({init_timeout})
         )
 
     # check init's output
-    with open(PILOT_STORAGE_DIR / "initoutput") as f:
+    with open(PILOT_STORE_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
 
@@ -1047,7 +1050,7 @@ raise ValueError('no good!')
         )
 
     # check init's output
-    with open(PILOT_STORAGE_DIR / "initoutput") as f:
+    with open(PILOT_STORE_DIR / "initoutput") as f:
         assert f.read().strip() == "hello world!"
 
 
@@ -1091,7 +1094,7 @@ with open(os.getenv('EWMS_TASK_PILOT_STORE_DIR') + '/initoutput', 'w') as f:
     )
 
     # check init's output
-    with open(PILOT_STORAGE_DIR / "initoutput") as f:
+    with open(PILOT_STORE_DIR / "initoutput") as f:
         assert f.read().strip() == "blue"
 
     # check task stuff


### PR DESCRIPTION
When using Singularity on Condor EPs, the root dir `/` is not writable (only readable), so `ewms-pilot-data/` needs to be rooted in an accessible location.