### PR TITLE
Support Singularity/Apptainer Directory Image

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -310,6 +310,7 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
+                  set -x  # lets see the command
                   # figure which image to run -- can't do first few tests b/c they're for rabbitmq only
                   if [[ $i == 10 ]]; then
                       # pilot pulls & converts to apptainer dir
@@ -321,6 +322,7 @@ jobs:
                   else
                       ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
                   fi
+                  set +x
           
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && mv $temp_dir . && temp_dir=$PWD/$(basename $temp_dir) && trap 'rm -rf $temp_dir' EXIT  # save disk space

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -226,6 +226,7 @@ jobs:
         run: |
           pip install .[test]  # for the for-loop below
           pytest --collect-only -q --disable-warnings tests | head -n -2 > $SORTED_LIST_OF_TESTS_FILE
+          cat $SORTED_LIST_OF_TESTS_FILE
 
       - if: ${{ matrix.container_platform == 'docker' }}
         run: |

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -324,7 +324,7 @@ jobs:
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-2/dir-B,target=/cvmfs/dummy-2/dir-B,readonly \
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
                       --env CI_TEST_ALPINE_PYTHON_IMAGE="/saved-images/python_alpine_sandbox/" \
-                      --env CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF="saved-images/python_alpine.sif" \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF="/saved-images/python_alpine.sif" \
                       --env CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_FROM_DOCKER="python:alpine" \
                       --env CI=$CI \
                       --workdir "$temp_dir" -B "$temp_dir" \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -209,6 +209,8 @@ jobs:
               cd saved-images/
               # building as a sandbox (unpacked dir) allows apptainer-in-apptainer
               apptainer build --sandbox python_alpine_sandbox/ docker://python:alpine
+              # pilot converts .sif to apptainer dir -- only 1 test uses this
+              apptainer build saved-images/python_alpine.sif docker://python:alpine
           else
               exit 2  # unknown container_platform
           fi
@@ -310,19 +312,6 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
-                  # figure which image to run -- can't do first few tests b/c they're for rabbitmq only
-                  if [[ $i == 10 ]]; then
-                      # pilot pulls docker & converts to apptainer dir
-                      ci_test_alpine_python_image="python:alpine"
-                  elif [[ $i == 11 ]]; then
-                      # pilot converts .sif to apptainer dir
-                      ci_test_alpine_python_image="saved-images/python_alpine.sif"
-                      apptainer build $ci_test_alpine_python_image docker://python:alpine
-                  else
-                      # use apptainer dir
-                      ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
-                  fi
-          
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && trap 'rm -rf $temp_dir' EXIT  # save disk space
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality
@@ -334,7 +323,9 @@ jobs:
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-1/dir-A,target=/cvmfs/dummy-1/dir-A,readonly \
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-2/dir-B,target=/cvmfs/dummy-2/dir-B,readonly \
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
-                      --env CI_TEST_ALPINE_PYTHON_IMAGE=$ci_test_alpine_python_image \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE="/saved-images/python_alpine_sandbox/" \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF="saved-images/python_alpine.sif" \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_FROM_DOCKER="python:alpine" \
                       --env CI=$CI \
                       --workdir "$temp_dir" -B "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -310,19 +310,17 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
-                  set -x  # lets see the command
                   # figure which image to run -- can't do first few tests b/c they're for rabbitmq only
                   if [[ $i == 10 ]]; then
                       # pilot pulls & converts to apptainer dir
                       ci_test_alpine_python_image="python:alpine"
                   elif [[ $i == 11 ]]; then
                       # pilot converts .sif to apptainer dir
-                      ci_test_alpine_python_image="/saved-images/python_alpine.sif"
+                      ci_test_alpine_python_image="saved-images/python_alpine.sif"
                       apptainer build $ci_test_alpine_python_image docker://python:alpine
                   else
                       ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
                   fi
-                  set +x
           
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && mv $temp_dir . && temp_dir=$PWD/$(basename $temp_dir) && trap 'rm -rf $temp_dir' EXIT  # save disk space

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -336,7 +336,7 @@ jobs:
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
                       --env CI_TEST_ALPINE_PYTHON_IMAGE=$ci_test_alpine_python_image \
                       --env CI=$CI \
-                      --workdir "$temp_dir" --pwd "$temp_dir" -B "$temp_dir" \
+                      --workdir "$temp_dir" -B "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \
                       /bin/bash -c "ls -l && ls -l / && pytest -vvv /app/$test" \
                       >> $(basename $test).test.out 2>&1 & pidlist="$pidlist $!"

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -310,11 +310,14 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
-                  if [[ $i == 0 ]]; then
+                  # figure which image to run -- can't do first few tests b/c they're for rabbitmq only
+                  if [[ $i == 10 ]]; then
                       # pilot pulls & converts to apptainer dir
                       ci_test_alpine_python_image="python:alpine"
-                  elif [[ $i == 1 ]]; then
+                  elif [[ $i == 11 ]]; then
+                      # pilot converts .sif to apptainer dir
                       ci_test_alpine_python_image="/saved-images/python_alpine.sif"
+                      apptainer build $ci_test_alpine_python_image docker://python:alpine
                   else
                       ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
                   fi

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -207,7 +207,6 @@ jobs:
               docker pull python:alpine && docker save -o saved-images/python-alpine.tar python:alpine
           elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
               cd saved-images/
-              mkdir python_alpine_sandbox
               # building as a sandbox (unpacked dir) allows apptainer-in-apptainer
               apptainer build --sandbox python_alpine_sandbox/ docker://python:alpine
           else

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -207,7 +207,9 @@ jobs:
               docker pull python:alpine && docker save -o saved-images/python-alpine.tar python:alpine
           elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
               cd saved-images/
-              apptainer pull docker://python:alpine
+              mkdir python_alpine_sandbox
+              # building as a sandbox (unpacked dir) allows apptainer-in-apptainer
+              apptainer build --sandbox python_alpine_sandbox/ docker://python:alpine
           else
               exit 2  # unknown container_platform
           fi
@@ -312,7 +314,6 @@ jobs:
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && mv $temp_dir . && temp_dir=$PWD/$(basename $temp_dir) && trap 'rm -rf $temp_dir' EXIT  # save disk space
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality
-                  # 'sudo + --keep-privs' in order to run apptainer-in-apptainer
                   # '--workdir' allows using host disk instead of memory
                   sleep "$(($i*$test_offset_delay))" && apptainer run \
                       --containall --writable-tmpfs --no-eval \
@@ -321,7 +322,7 @@ jobs:
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-1/dir-A,target=/cvmfs/dummy-1/dir-A,readonly \
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-2/dir-B,target=/cvmfs/dummy-2/dir-B,readonly \
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
-                      --env CI_TEST_ALPINE_PYTHON_IMAGE="/saved-images/python_alpine.sif" \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE="/saved-images/python_alpine_sandbox/" \
                       --env CI=$CI \
                       --workdir "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -351,7 +351,7 @@ jobs:
               date --rfc-3339=seconds
               echo "waiting for $pid..."
               if ! wait -n $pid; then
-                  echo "ERROR: test(s) failed"
+                  echo "ERROR: test(s) failed (ctrl+f $pid to match)"
                   sleep 5  # may need to wait for output files to be written
                   kill $pidlist 2>/dev/null
                   exit 1

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -324,7 +324,7 @@ jobs:
                   fi
           
                   set -x  # lets see the command
-                  temp_dir=$(mktemp -d) && mv $temp_dir . && temp_dir=$PWD/$(basename $temp_dir) && trap 'rm -rf $temp_dir' EXIT  # save disk space
+                  temp_dir=$(mktemp -d) && trap 'rm -rf $temp_dir' EXIT  # save disk space
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality
                   # '--workdir' allows using host disk instead of memory
                   sleep "$(($i*$test_offset_delay))" && apptainer run \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -312,7 +312,9 @@ jobs:
           
                   if [[ $i == 0 ]]; then
                       # pilot pulls & converts to apptainer dir
-                      ci_test_alpine_python_image="python:alpine"    
+                      ci_test_alpine_python_image="python:alpine"
+                  elif [[ $i == 1 ]]; then
+                      ci_test_alpine_python_image="/saved-images/python_alpine.sif"
                   else
                       ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
                   fi
@@ -330,7 +332,7 @@ jobs:
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
                       --env CI_TEST_ALPINE_PYTHON_IMAGE=$ci_test_alpine_python_image \
                       --env CI=$CI \
-                      --workdir "$temp_dir" --pwd "$temp_dir" \
+                      --workdir "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \
                       /bin/bash -c "ls -l && ls -l / && pytest -vvv /app/$test" \
                       >> $(basename $test).test.out 2>&1 & pidlist="$pidlist $!"

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -310,6 +310,13 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
+                  if [[ $i == 0 ]]; then
+                      # pilot pulls & converts to apptainer dir
+                      ci_test_alpine_python_image="python:alpine"    
+                  else
+                      ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
+                  fi
+          
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && mv $temp_dir . && temp_dir=$PWD/$(basename $temp_dir) && trap 'rm -rf $temp_dir' EXIT  # save disk space
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality
@@ -321,9 +328,9 @@ jobs:
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-1/dir-A,target=/cvmfs/dummy-1/dir-A,readonly \
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-2/dir-B,target=/cvmfs/dummy-2/dir-B,readonly \
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
-                      --env CI_TEST_ALPINE_PYTHON_IMAGE="/saved-images/python_alpine_sandbox/" \
+                      --env CI_TEST_ALPINE_PYTHON_IMAGE=$ci_test_alpine_python_image \
                       --env CI=$CI \
-                      --workdir "$temp_dir" \
+                      --workdir "$temp_dir" --pwd "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \
                       /bin/bash -c "ls -l && ls -l / && pytest -vvv /app/$test" \
                       >> $(basename $test).test.out 2>&1 & pidlist="$pidlist $!"

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -316,7 +316,6 @@ jobs:
                   # '--workdir' allows using host disk instead of memory
                   sleep "$(($i*$test_offset_delay))" && apptainer run \
                       --containall --writable-tmpfs --no-eval \
-                      --keep-privs \
                       --mount type=bind,source=$(pwd),target=/repo/,readonly \
                       --mount type=bind,source=$(pwd)/saved-images,target=/saved-images/ \
                       --mount type=bind,source=$(pwd)/cvmfs/dummy-1/dir-A,target=/cvmfs/dummy-1/dir-A,readonly \

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -210,7 +210,7 @@ jobs:
               # building as a sandbox (unpacked dir) allows apptainer-in-apptainer
               apptainer build --sandbox python_alpine_sandbox/ docker://python:alpine
               # pilot converts .sif to apptainer dir -- only 1 test uses this
-              apptainer build saved-images/python_alpine.sif docker://python:alpine
+              apptainer build python_alpine.sif docker://python:alpine
           else
               exit 2  # unknown container_platform
           fi

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -312,13 +312,14 @@ jobs:
           
                   # figure which image to run -- can't do first few tests b/c they're for rabbitmq only
                   if [[ $i == 10 ]]; then
-                      # pilot pulls & converts to apptainer dir
+                      # pilot pulls docker & converts to apptainer dir
                       ci_test_alpine_python_image="python:alpine"
                   elif [[ $i == 11 ]]; then
                       # pilot converts .sif to apptainer dir
                       ci_test_alpine_python_image="saved-images/python_alpine.sif"
                       apptainer build $ci_test_alpine_python_image docker://python:alpine
                   else
+                      # use apptainer dir
                       ci_test_alpine_python_image="/saved-images/python_alpine_sandbox/"
                   fi
           
@@ -335,7 +336,7 @@ jobs:
                       $(env | grep '^EWMS_' | awk '$0="--env "$0') \
                       --env CI_TEST_ALPINE_PYTHON_IMAGE=$ci_test_alpine_python_image \
                       --env CI=$CI \
-                      --workdir "$temp_dir" \
+                      --workdir "$temp_dir" --pwd "$temp_dir" -B "$temp_dir" \
                       $(basename ${{ env.DOCKER_IMAGE_NAME }}).sif \
                       /bin/bash -c "ls -l && ls -l / && pytest -vvv /app/$test" \
                       >> $(basename $test).test.out 2>&1 & pidlist="$pidlist $!"

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -314,7 +314,7 @@ jobs:
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality
                   # 'sudo + --keep-privs' in order to run apptainer-in-apptainer
                   # '--workdir' allows using host disk instead of memory
-                  sleep "$(($i*$test_offset_delay))" && sudo apptainer run \
+                  sleep "$(($i*$test_offset_delay))" && apptainer run \
                       --containall --writable-tmpfs --no-eval \
                       --keep-privs \
                       --mount type=bind,source=$(pwd),target=/repo/,readonly \

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # wipac-dev-py-setup-action
 !dependencies*.log
+
+.idea/
+

--- a/ewms_pilot/config.py
+++ b/ewms_pilot/config.py
@@ -101,6 +101,7 @@ class EnvConfig:
 
     # non-user set settings
     _EWMS_PILOT_CONTAINER_PLATFORM: str = "docker"
+    _EWMS_PILOT_APPTAINER_WORKDIR: str = "/var/tmp"
     CI: bool = False  # github actions sets this to 'true'
 
     def __post_init__(self) -> None:

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -139,6 +139,9 @@ class ContainerRunner:
                     if not Path(image).exists():
                         raise FileNotFoundError(image)
                     return image
+                # sandbox / unpacked directory format -- check if exists
+                elif Path(image).is_dir():
+                    return image
                 # docker image -- pull & convert
                 else:
                     docker_image = f"docker://{image}"

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -146,7 +146,7 @@ class ContainerRunner:
                     return image
                 # assume non-specified image is docker -- https://apptainer.org/docs/user/latest/build_a_container.html#overview
                 if "." not in image and "://" not in image:
-                    # is not a blah.sif file and doesn't point to a registry
+                    # is not a blah.sif file (or other) and doesn't point to a registry
                     image = f"docker://{image}"
                 # name it something that is recognizable -- and put it where there is enough space
                 dir_image = (

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -144,14 +144,14 @@ class ContainerRunner:
                     return image
                 # docker image -- pull & convert
                 else:
-                    docker_image = f"docker://{image}"
+                    dir_image = "image_in_a_sandbox/"
                     subprocess.run(
-                        f"apptainer pull {docker_image}",
+                        f"apptainer build --sandbox {dir_image} docker://{image}",
                         text=True,
                         check=True,
                         shell=True,
                     )
-                    return docker_image
+                    return dir_image
 
             case other:
                 raise ValueError(

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -141,14 +141,14 @@ class ContainerRunner:
                 if "." not in image and "://" not in image:
                     image = f"docker://{image}"
                 # run
-                dir_image = f"{image.replace('://', '_').replace('/', '_')}/"
+                dir_image = f"{ENV._EWMS_PILOT_APPTAINER_WORKDIR}/{image.replace('://', '_').replace('/', '_')}/"
                 subprocess.run(
-                    f"apptainer build --sandbox {dir_image} {image}",
+                    f"cd {ENV._EWMS_PILOT_APPTAINER_WORKDIR} && apptainer build --sandbox {dir_image} {image}",
                     text=True,
                     check=True,
                     shell=True,
                 )
-                return image
+                return dir_image
 
             case other:
                 raise ValueError(

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -134,24 +134,21 @@ class ContainerRunner:
                 return image
 
             case "apptainer":
-                # .sif -- check if file exists
-                if image.endswith(".sif"):
-                    if not Path(image).exists():
-                        raise FileNotFoundError(image)
+                # only are able to run unpacked directory format
+                if Path(image).is_dir():
                     return image
-                # sandbox / unpacked directory format -- check if exists
-                elif Path(image).is_dir():
-                    return image
-                # docker image -- pull & convert
-                else:
-                    dir_image = "image_in_a_sandbox/"
-                    subprocess.run(
-                        f"apptainer build --sandbox {dir_image} docker://{image}",
-                        text=True,
-                        check=True,
-                        shell=True,
-                    )
-                    return dir_image
+                # assume non-specified image is docker -- https://apptainer.org/docs/user/latest/build_a_container.html#overview
+                if "." not in image and "://" not in image:
+                    image = f"docker://{image}"
+                # run
+                dir_image = "image_in_a_sandbox/"
+                subprocess.run(
+                    f"apptainer build --sandbox {dir_image} {image}",
+                    text=True,
+                    check=True,
+                    shell=True,
+                )
+                return image
 
             case other:
                 raise ValueError(

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -141,7 +141,7 @@ class ContainerRunner:
                 if "." not in image and "://" not in image:
                     image = f"docker://{image}"
                 # run
-                dir_image = "image_in_a_sandbox/"
+                dir_image = f"{image.replace('://', '_').replace('/', '_')}/"
                 subprocess.run(
                     f"apptainer build --sandbox {dir_image} {image}",
                     text=True,

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -146,6 +146,7 @@ class ContainerRunner:
                     return image
                 # assume non-specified image is docker -- https://apptainer.org/docs/user/latest/build_a_container.html#overview
                 if "." not in image and "://" not in image:
+                    # is not a blah.sif file and doesn't point to a registry
                     image = f"docker://{image}"
                 # name it something that is recognizable -- and put it where there is enough space
                 dir_image = (

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -196,20 +196,20 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
 @pytest.mark.parametrize(
     "image",
     [
-        os.getenv("CI_TEST_ALPINE_PYTHON_IMAGE"),
+        "CI_TEST_ALPINE_PYTHON_IMAGE",
         pytest.param(
-            os.getenv("CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF"),
+            "CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF",
             marks=pytest.mark.skipif(ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer"),
         ),
         pytest.param(
-            os.getenv("CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_FROM_DOCKER"),
+            "CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_FROM_DOCKER",
             marks=pytest.mark.skipif(ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer"),
         ),
     ],
 )
 @pytest.mark.usefixtures("unique_pwd")
 async def test_000(
-    image: str,
+    image_envvar: str,
     queue_incoming: str,
     queue_outgoing: str,
 ) -> None:
@@ -225,7 +225,7 @@ async def test_000(
             intermittent_sleep=TIMEOUT_INCOMING / 4,
         ),
         consume_and_reply(
-            image,
+            os.environ[image_envvar],
             """python3 -c "
 output = open('{{INFILE}}').read().strip() * 2;
 print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -199,11 +199,17 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
         "CI_TEST_ALPINE_PYTHON_IMAGE",
         pytest.param(
             "CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF",
-            marks=pytest.mark.skipif(ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer"),
+            marks=pytest.mark.skipif(
+                ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer",
+                reason="test only for apptainer",
+            ),
         ),
         pytest.param(
             "CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_FROM_DOCKER",
-            marks=pytest.mark.skipif(ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer"),
+            marks=pytest.mark.skipif(
+                ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer",
+                reason="test only for apptainer",
+            ),
         ),
     ],
 )

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -196,7 +196,7 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
 @pytest.mark.parametrize(
     "image",
     [
-        os.environ["CI_TEST_ALPINE_PYTHON_IMAGE"],
+        os.getenv("CI_TEST_ALPINE_PYTHON_IMAGE"),
         pytest.param(
             os.getenv("CI_TEST_ALPINE_PYTHON_IMAGE_APPTAINER_SIF"),
             marks=pytest.mark.skipif(ENV._EWMS_PILOT_CONTAINER_PLATFORM != "apptainer"),

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -194,7 +194,7 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
 
 
 @pytest.mark.parametrize(
-    "image",
+    "image_envvar",
     [
         "CI_TEST_ALPINE_PYTHON_IMAGE",
         pytest.param(


### PR DESCRIPTION
Allow a singularity/apptainer directory for	the task image. We can't rely on sudo + `--keep-privs` in production for `apptainer run`.

Internally, for	Apptainer, all images are converted to unpacked directories. See https://apptainer.org/docs/user/latest/build_a_container.html#overview