### PR TITLE
Remove `--writable-tmpfs` from Task Container

### DIFF
--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -202,7 +202,7 @@ class ContainerRunner:
             case "apptainer":
                 cmd = (
                     f"apptainer run "
-                    f"--containall --writable-tmpfs --no-eval "  # gets us close to docker functionality
+                    f"--containall --no-eval "  # gets us close to docker functionality
                     f"{mount_bindings} "
                     f"{env_options} "
                     f"{self.image} {inst_args}"


### PR DESCRIPTION
Condor gave `Subprocess completed with exit code 255: fuse-overlayfs: cannot mount: No such file or directory`. Perhaps this is due to `--writable-tmpfs` needing FUSE. Without it, we'll need to bind needed dirs, though this is application/task-specific.