### PR TITLE
Remove `--writable-tmpfs` and Avoid Pitfalls with Overlays

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -303,8 +303,8 @@ jobs:
           echo "beta" > $(pwd)/cvmfs/dummy-2/dir-B/file.txt
           
           # figure how long to wait between tests
-          if [[ "${{ matrix.broker_client }}" == 'rabbitmq' ]]; then
-              test_offset_delay=20  # rabbitmq on docker gets overwhelmed for some reason
+          if [[ "${{ matrix.container_platform }}" == 'docker' && "${{ matrix.broker_client }}" == 'rabbitmq' ]]; then
+              test_offset_delay=15  # rabbitmq on docker gets overwhelmed for some reason
           else
               test_offset_delay=5
           fi

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -179,6 +179,12 @@ jobs:
         with:
           python-version: ${{ matrix.version }}
 
+      - if: ${{ matrix.broker_client == 'rabbitmq' }}
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: false  # this is a LOT of space, so it takes longer to remove
+          docker-images: false  # we may actually need this one
+
       - if: ${{ matrix.container_platform == 'docker' }}
         name: install sysbox (needed for docker-in-docker)
         run: |
@@ -302,12 +308,7 @@ jobs:
           mkdir -p $(pwd)/cvmfs/dummy-2/dir-B
           echo "beta" > $(pwd)/cvmfs/dummy-2/dir-B/file.txt
           
-          # figure how long to wait between tests
-          if [[ "${{ matrix.container_platform }}" == 'docker' && "${{ matrix.broker_client }}" == 'rabbitmq' ]]; then
-              test_offset_delay=15  # rabbitmq on docker gets overwhelmed for some reason
-          else
-              test_offset_delay=5
-          fi
+          test_offset_delay=5
 
           # iterate each test, starting each in its own container
           cat $SORTED_LIST_OF_TESTS_FILE

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -340,6 +340,8 @@ jobs:
           
               elif [[ "${{ matrix.container_platform }}" == "apptainer" ]]; then
           
+                  # NOTE: we want to mimic how htcondor launches apptainer-enabled EPs
+          
                   set -x  # lets see the command
                   temp_dir=$(mktemp -d) && trap 'rm -rf $temp_dir' EXIT  # save disk space
                   # '--containall --writable-tmpfs --no-eval' gets us close to docker functionality

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -224,7 +224,7 @@ class ContainerRunner:
                 cmd = (
                     f"apptainer run "
                     f"--containall "  # don't auto-mount anything
-                    f"--no-eval "  # don't interpret vars
+                    f"--no-eval "  # don't interpret CL args
                     f"{mount_bindings} "
                     f"{env_options} "
                     f"{self.image} {inst_args}"

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -223,7 +223,8 @@ class ContainerRunner:
             case "apptainer":
                 cmd = (
                     f"apptainer run "
-                    f"--containall --writable-tmpfs --no-eval "  # gets us close to docker functionality
+                    f"--containall "  # don't auto-mount anything
+                    f"--no-eval "  # don't interpret vars
                     f"{mount_bindings} "
                     f"{env_options} "
                     f"{self.image} {inst_args}"


### PR DESCRIPTION
For wider compatibility on HTCondor, remove the need for overlays: remove `--writable-tmpfs`.

This was seen with prebuilt Apptainer directory images on CVMFS.