### PR TITLE
Fix Message Handling for No-Output Tasks

### DIFF
--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -268,7 +268,7 @@ jobs:
           docker network create mynet
 
       - name: Integrate
-        timeout-minutes: ${{ matrix.broker_client == 'rabbitmq' && '20' ||  '10'  }}  # adjust if fails, remember this is only time for *this* step
+        timeout-minutes: ${{ matrix.broker_client == 'rabbitmq' && 20  ||  10  }}  # adjust if fails, remember this is only time for *this* step
         run: |
           set -x
           

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -265,6 +265,7 @@ jobs:
           docker network create mynet
 
       - name: Integrate
+        timeout-minutes: ${{ matrix.broker_client == 'rabbitmq' && 20  ||  10  }}  # adjust if fails, remember this is only time for *this* step
         run: |
           set -x
           

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -7,10 +7,7 @@ on:
     tags-ignore:
       - '**'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # don't cancel on main/master/default
-  cancel-in-progress: ${{ format('refs/heads/{0}', github.event.repository.default_branch) != github.ref }}
+# not using concurrency -- it makes A/B debugging difficult. Now, manually cancel prev tests if needed
 
 env:
   RABBITMQ_IMAGE_TAG: bitnami/rabbitmq:3.13.5

--- a/.github/workflows/wipac-cicd.yml
+++ b/.github/workflows/wipac-cicd.yml
@@ -265,7 +265,6 @@ jobs:
           docker network create mynet
 
       - name: Integrate
-        timeout-minutes: ${{ matrix.broker_client == 'rabbitmq' && 20  ||  10  }}  # adjust if fails, remember this is only time for *this* step
         run: |
           set -x
           

--- a/dependencies-logs/dependencies-docker-3.10-nats-test.log
+++ b/dependencies-logs/dependencies-docker-3.10-nats-test.log
@@ -19,7 +19,7 @@ nkeys==0.2.0
 oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -46,22 +46,22 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.10-nats.log
+++ b/dependencies-logs/dependencies-docker-3.10-nats.log
@@ -36,8 +36,8 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
-setuptools==70.1.0
-wheel==0.43.0
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.10-pulsar-test.log
+++ b/dependencies-logs/dependencies-docker-3.10-pulsar-test.log
@@ -18,7 +18,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
 pulsar-client==3.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -43,24 +43,24 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.10-pulsar.log
+++ b/dependencies-logs/dependencies-docker-3.10-pulsar.log
@@ -33,10 +33,10 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.10-rabbitmq-test.log
+++ b/dependencies-logs/dependencies-docker-3.10-rabbitmq-test.log
@@ -18,7 +18,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pika==1.3.2
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -44,22 +44,22 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── exceptiongroup [required: >=1.0.0rc8, installed: 1.2.2]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     ├── pluggy [required: >=1.5,<2, installed: 1.5.0]
     └── tomli [required: >=1, installed: 2.0.1]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.10-rabbitmq.log
+++ b/dependencies-logs/dependencies-docker-3.10-rabbitmq.log
@@ -34,8 +34,8 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
-setuptools==70.1.0
-wheel==0.43.0
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-nats-test.log
+++ b/dependencies-logs/dependencies-docker-3.11-nats-test.log
@@ -18,7 +18,7 @@ nkeys==0.2.0
 oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -44,18 +44,18 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-nats.log
+++ b/dependencies-logs/dependencies-docker-3.11-nats.log
@@ -36,8 +36,8 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
-setuptools==70.1.0
-wheel==0.43.0
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-pulsar-test.log
+++ b/dependencies-logs/dependencies-docker-3.11-pulsar-test.log
@@ -17,7 +17,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
 pulsar-client==3.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -41,20 +41,20 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-pulsar.log
+++ b/dependencies-logs/dependencies-docker-3.11-pulsar.log
@@ -33,10 +33,10 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-rabbitmq-test.log
+++ b/dependencies-logs/dependencies-docker-3.11-rabbitmq-test.log
@@ -17,7 +17,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pika==1.3.2
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -42,18 +42,18 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
-setuptools==70.1.0
-wheel==0.43.0
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.11-rabbitmq.log
+++ b/dependencies-logs/dependencies-docker-3.11-rabbitmq.log
@@ -34,8 +34,8 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
-setuptools==70.1.0
-wheel==0.43.0
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
+setuptools==74.1.2
+wheel==0.44.0

--- a/dependencies-logs/dependencies-docker-3.12-nats-test.log
+++ b/dependencies-logs/dependencies-docker-3.12-nats-test.log
@@ -18,7 +18,7 @@ nkeys==0.2.0
 oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -44,16 +44,16 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]

--- a/dependencies-logs/dependencies-docker-3.12-nats.log
+++ b/dependencies-logs/dependencies-docker-3.12-nats.log
@@ -36,6 +36,6 @@ ewms-pilot
     └── zstd [required: Any, installed: 1.5.5.1]
 nats-py==2.9.0
 nkeys==0.2.0
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]

--- a/dependencies-logs/dependencies-docker-3.12-pulsar-test.log
+++ b/dependencies-logs/dependencies-docker-3.12-pulsar-test.log
@@ -17,7 +17,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pluggy==1.5.0
 pulsar-client==3.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -41,18 +41,18 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]

--- a/dependencies-logs/dependencies-docker-3.12-pulsar.log
+++ b/dependencies-logs/dependencies-docker-3.12-pulsar.log
@@ -33,8 +33,8 @@ ewms-pilot
     │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.2.2]
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pulsar-client==3.5.0
 └── certifi [required: Any, installed: 2024.8.30]

--- a/dependencies-logs/dependencies-docker-3.12-rabbitmq-test.log
+++ b/dependencies-logs/dependencies-docker-3.12-rabbitmq-test.log
@@ -17,7 +17,7 @@ oms-mqclient==2.6.0
 packaging==24.1
 pika==1.3.2
 pluggy==1.5.0
-pytest==8.3.2
+pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-retry==1.6.3
 requests==2.32.3
@@ -42,16 +42,16 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]
 pytest-asyncio==0.24.0
-└── pytest [required: >=8.2,<9, installed: 8.3.2]
+└── pytest [required: >=8.2,<9, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]
 pytest-retry==1.6.3
-└── pytest [required: >=7.0.0, installed: 8.3.2]
+└── pytest [required: >=7.0.0, installed: 8.3.3]
     ├── iniconfig [required: Any, installed: 2.0.0]
     ├── packaging [required: Any, installed: 24.1]
     └── pluggy [required: >=1.5,<2, installed: 1.5.0]

--- a/dependencies-logs/dependencies-docker-3.12-rabbitmq.log
+++ b/dependencies-logs/dependencies-docker-3.12-rabbitmq.log
@@ -34,6 +34,6 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]

--- a/dependencies-logs/dependencies-docker-default.log
+++ b/dependencies-logs/dependencies-docker-default.log
@@ -34,6 +34,6 @@ ewms-pilot
     │   └── typing_extensions [required: Any, installed: 4.12.2]
     └── zstd [required: Any, installed: 1.5.5.1]
 pika==1.3.2
-pipdeptree==2.23.1
-├── packaging [required: >=23.1, installed: 24.1]
-└── pip [required: >=23.1.2, installed: 24.2]
+pipdeptree==2.23.3
+├── packaging [required: >=24.1, installed: 24.1]
+└── pip [required: >=24.2, installed: 24.2]

--- a/ewms_pilot/pilot.py
+++ b/ewms_pilot/pilot.py
@@ -318,7 +318,7 @@ async def _consume_and_reply(
                 sub,
                 pub,
                 pending,
-                previous_task_errors=task_errors,
+                prev_task_errors=task_errors,
                 timeout=REFRESH_INTERVAL,
             )
             await housekeeper.new_messages_done(
@@ -343,7 +343,7 @@ async def _consume_and_reply(
                 sub,
                 pub,
                 pending,
-                previous_task_errors=task_errors,
+                prev_task_errors=task_errors,
                 timeout=REFRESH_INTERVAL,
             )
             await housekeeper.new_messages_done(

--- a/ewms_pilot/tasks/wait_on_tasks.py
+++ b/ewms_pilot/tasks/wait_on_tasks.py
@@ -14,29 +14,30 @@ LOGGER = logging.getLogger(__name__)
 AsyncioTaskMessages = dict[asyncio.Task, Message]  # type: ignore[type-arg]
 
 
-async def _handle_failed_task(
-    previous_task_errors: list[BaseException],
+async def _nack_and_record_error(
+    prev_task_errors: list[BaseException],
     exception: BaseException,
     sub: mq.queue.ManualQueueSubResource,
     msg: Message,
 ) -> None:  # type: ignore[type-arg]
-    previous_task_errors.append(exception)
+    LOGGER.exception(exception)
+    prev_task_errors.append(exception)
     LOGGER.error(
-        f"TASK FAILED ({repr(exception)}) -- attempting to nack original message..."
+        f"TASK FAILED ({repr(exception)}) -- attempting to nack input-event message..."
     )
     try:
         await sub.nack(msg)
     except Exception as e:
         # LOGGER.exception(e)
         LOGGER.error(f"Could not nack: {repr(e)}")
-    LOGGER.error(all_task_errors_string(previous_task_errors))
+    LOGGER.error(all_task_errors_string(prev_task_errors))
 
 
 async def wait_on_tasks_with_ack(
     sub: mq.queue.ManualQueueSubResource,
     pub: mq.queue.QueuePubResource,
     tasks_msgs: AsyncioTaskMessages,
-    previous_task_errors: list[BaseException],
+    prev_task_errors: list[BaseException],
     timeout: int,
 ) -> tuple[AsyncioTaskMessages, list[BaseException]]:
     """Get finished tasks and ack/nack their messages.
@@ -48,10 +49,10 @@ async def wait_on_tasks_with_ack(
     """
     pending: set[asyncio.Task] = set(tasks_msgs.keys())  # type: ignore[type-arg]
     if not pending:
-        return {}, previous_task_errors
+        return {}, prev_task_errors
 
     # wait for next task
-    LOGGER.debug("Waiting on tasks...")
+    LOGGER.debug("Waiting on tasks to finish...")
     done, pending = await asyncio.wait(
         pending,
         return_when=asyncio.FIRST_COMPLETED,
@@ -62,42 +63,42 @@ async def wait_on_tasks_with_ack(
     # fyi, most likely one task in here, but 2+ could finish at same time
     for task in done:
         try:
-            result = await task
+            output_event = await task
+        # SUCCESSFUL TASK W/O OUTPUT -> is ok, but nothing to send...
         except NoTaskResponseException:
-            LOGGER.info("TASK FINISHED -- no message to send.")
-            continue
+            LOGGER.info("TASK FINISHED -- no output-event to send (this is ok).")
+        # FAILED TASK! -> nack input message
         except Exception as e:
-            LOGGER.exception(e)
-            # FAILED TASK!
-            await _handle_failed_task(previous_task_errors, e, sub, tasks_msgs[task])
+            await _nack_and_record_error(prev_task_errors, e, sub, tasks_msgs[task])
             continue
+        # SUCCESSFUL TASK W/ OUTPUT -> send...
+        else:
+            try:
+                LOGGER.info("TASK FINISHED -- attempting to send output-event...")
+                await pub.send(output_event)
+            except Exception as e:
+                # -> failed to send = FAILED TASK! -> nack input-event message
+                LOGGER.error(
+                    f"Failed to send finished task's output-event: {repr(e)}"
+                    f" -- the task is now considered failed."
+                )
+                await _nack_and_record_error(prev_task_errors, e, sub, tasks_msgs[task])
+                continue
 
-        # SUCCESSFUL TASK -> send result
+        # now, ack input message
         try:
-            LOGGER.info("TASK FINISHED -- attempting to send result message...")
-            await pub.send(result)
-        except Exception as e:
-            # -> failed to send = FAILED TASK!
-            LOGGER.error(
-                f"Failed to send finished task's result: {repr(e)}"
-                f" -- task now considered as failed"
-            )
-            await _handle_failed_task(previous_task_errors, e, sub, tasks_msgs[task])
-            continue
-
-        # SUCCESSFUL TASK -> result sent -> ack original message
-        try:
-            LOGGER.info("Now, attempting to ack original message...")
+            LOGGER.info("Now, attempting to ack input-event message...")
             await sub.ack(tasks_msgs[task])
         except mq.broker_client_interface.AckException as e:
-            # -> result sent -> ack failed = that's okay!
+            # -> task finished -> ack failed = that's okay!
             LOGGER.error(
-                f"Could not ack ({repr(e)}) -- not counting as a failed task"
-                " since task's result was sent successfully -- "
+                f"Could not ack ({repr(e)}) -- not counted as a failed task"
+                " since task's output-event was sent successfully "
+                "(if there was an output, check logs to guarantee that). "
                 "NOTE: outgoing queue may eventually get"
-                " duplicate result when original message is"
+                " duplicate output-event when original message is"
                 " re-delivered by broker to another pilot"
-                " & the new result is sent"
+                " & the new output-event is sent."
             )
 
     if done:
@@ -106,5 +107,5 @@ async def wait_on_tasks_with_ack(
     return (
         {t: msg for t, msg in tasks_msgs.items() if t in pending},
         # this now also includes tasks that finished this round
-        previous_task_errors,
+        prev_task_errors,
     )

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -1234,71 +1234,71 @@ print(output, file=open(os.environ['EWMS_TASK_OUTFILE'],'w'))" """,  # double ca
     ########################################################################################
 
 
-# async def test_6000__task_env_vars(
-#     queue_incoming: str,
-#     queue_outgoing: str,
-# ) -> None:
-#     """Test a pilot that reads env vars that are defined for the task by the user."""
-#     msgs_to_subproc = MSGS_TO_SUBPROC
-#     msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
-#
-#     # set the env vars -- this will work fine as long as there is no immediate processing in package (like dataclass's __post_init__)
-#     # use object.__setattr__ b/c dataclass is frozen
-#     object.__setattr__(
-#         ENV, "EWMS_PILOT_INIT_ENV_JSON", json.dumps({"INIT_FOO": "BOT", "INIT_BAZ": 99})
-#     )
-#     object.__setattr__(
-#         ENV, "EWMS_PILOT_TASK_ENV_JSON", json.dumps({"FOO": "BAR", "BAZ": 100})
-#     )
-#
-#     # run producer & consumer concurrently
-#     await asyncio.gather(
-#         populate_queue(
-#             queue_incoming,
-#             msgs_to_subproc,
-#             intermittent_sleep=TIMEOUT_INCOMING / 4,
-#         ),
-#         consume_and_reply(
-#             f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
-#             """python3 -c "
-# import os
-# output = open('{{INFILE}}').read().strip() * 2;
-# assert os.environ['FOO'] == 'BAR'
-# assert os.environ['BAZ'] == '100'
-# print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
-#             #
-#             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
-#             init_args="""python3 -c "
-# import os
-# os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
-# assert os.environ['INIT_FOO'] == 'BOT'
-# assert os.environ['INIT_BAZ'] == '99'
-# with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
-#     print('writing hello world to a file...')
-#     print('hello world!', file=f)
-# " """,
-#             queue_incoming=queue_incoming,
-#             queue_outgoing=queue_outgoing,
-#             timeout_incoming=TIMEOUT_INCOMING,
-#         ),
-#     )
-#
-#     # check init's output
-#     with open(PILOT_DATA_DIR / PILOT_DATA_HUB_DIR_NAME / "initoutput") as f:
-#         assert f.read().strip() == "hello world!"
-#
-#     # check task stuff
-#     await assert_results(queue_outgoing, msgs_outgoing_expected)
-#     assert_pilot_dirs(
-#         len(msgs_outgoing_expected),
-#         [
-#             "task-io/infile-{UUID}.in",
-#             "task-io/outfile-{UUID}.out",
-#             "task-io/",
-#             "outputs/stderrfile",
-#             "outputs/stdoutfile",
-#             "outputs/",
-#         ],
-#         ["initoutput"],
-#         has_init_cmd_subdir=True,
-#     )
+async def test_6000__task_env_vars(
+    queue_incoming: str,
+    queue_outgoing: str,
+) -> None:
+    """Test a pilot that reads env vars that are defined for the task by the user."""
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}{x}\n" for x in msgs_to_subproc]
+
+    # set the env vars -- this will work fine as long as there is no immediate processing in package (like dataclass's __post_init__)
+    # use object.__setattr__ b/c dataclass is frozen
+    object.__setattr__(
+        ENV, "EWMS_PILOT_INIT_ENV_JSON", json.dumps({"INIT_FOO": "BOT", "INIT_BAZ": 99})
+    )
+    object.__setattr__(
+        ENV, "EWMS_PILOT_TASK_ENV_JSON", json.dumps({"FOO": "BAR", "BAZ": 100})
+    )
+
+    # run producer & consumer concurrently
+    await asyncio.gather(
+        populate_queue(
+            queue_incoming,
+            msgs_to_subproc,
+            intermittent_sleep=TIMEOUT_INCOMING / 4,
+        ),
+        consume_and_reply(
+            f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
+            """python3 -c "
+import os
+output = open('{{INFILE}}').read().strip() * 2;
+assert os.environ['FOO'] == 'BAR'
+assert os.environ['BAZ'] == '100'
+print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
+            #
+            init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
+            init_args="""python3 -c "
+import os
+os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
+assert os.environ['INIT_FOO'] == 'BOT'
+assert os.environ['INIT_BAZ'] == '99'
+with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
+    print('writing hello world to a file...')
+    print('hello world!', file=f)
+" """,
+            queue_incoming=queue_incoming,
+            queue_outgoing=queue_outgoing,
+            timeout_incoming=TIMEOUT_INCOMING,
+        ),
+    )
+
+    # check init's output
+    with open(PILOT_DATA_DIR / PILOT_DATA_HUB_DIR_NAME / "initoutput") as f:
+        assert f.read().strip() == "hello world!"
+
+    # check task stuff
+    await assert_results(queue_outgoing, msgs_outgoing_expected)
+    assert_pilot_dirs(
+        len(msgs_outgoing_expected),
+        [
+            "task-io/infile-{UUID}.in",
+            "task-io/outfile-{UUID}.out",
+            "task-io/",
+            "outputs/stderrfile",
+            "outputs/stdoutfile",
+            "outputs/",
+        ],
+        ["initoutput"],
+        has_init_cmd_subdir=True,
+    )

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -8,7 +8,9 @@ import os
 import pickle
 import re
 import time
+import uuid
 from datetime import date, timedelta
+from pathlib import Path
 from pprint import pprint
 from typing import List, Optional
 from unittest.mock import patch
@@ -28,6 +30,16 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 TIMEOUT_INCOMING = 3
 
 MSGS_TO_SUBPROC = ["item" + str(i) for i in range(30)]
+
+
+@pytest.fixture
+def unique_pwd() -> None:
+    """Create unique directory and cd to it.
+    Enables tests to be ran in parallel without file conflicts.
+    """
+    root = Path(uuid.uuid4().hex)
+    root.mkdir()
+    os.chdir(root)
 
 
 @pytest.fixture
@@ -162,6 +174,7 @@ TEST_1000_SLEEP = 150.0  # anything lower doesn't upset rabbitmq enough
         TEST_1000_SLEEP / 10,  # will have no hb issues
     ],
 )
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_1000__heartbeat_workaround__rabbitmq_only(
     queue_incoming: str,
     queue_outgoing: str,
@@ -199,6 +212,7 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
         ),
     ],
 )
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_000(
     image_envvar: str,
     queue_incoming: str,
@@ -240,6 +254,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_001__txt__str_filetype(
     queue_incoming: str,
     queue_outgoing: str,
@@ -282,6 +297,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_100__json__objects(
     queue_incoming: str,
     queue_outgoing: str,
@@ -329,6 +345,7 @@ json.dump(output, open('{{OUTFILE}}','w'))" """,
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_101__json__preserialized(
     queue_incoming: str,
     queue_outgoing: str,
@@ -376,6 +393,7 @@ json.dump(output, open('{{OUTFILE}}','w'))" """,
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_200__pkl_b64(
     queue_incoming: str,
     queue_outgoing: str,
@@ -440,6 +458,7 @@ print(outdata, file=open('{{OUTFILE}}','w'), end='')" """,
 
 
 @pytest.mark.parametrize("quarantine", [None, 20])
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_400__exception_quarantine(
     queue_incoming: str,
     queue_outgoing: str,
@@ -491,6 +510,7 @@ async def test_400__exception_quarantine(
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_420__timeout(
     queue_incoming: str,
     queue_outgoing: str,
@@ -557,6 +577,7 @@ PREFETCH_TEST_PARAMETERS = sorted(
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_500__concurrent_load_max_concurrent_tasks(
     queue_incoming: str,
     queue_outgoing: str,
@@ -614,6 +635,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     condition=config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE == "rabbitmq",
 )
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_510__concurrent_load_max_concurrent_tasks_exceptions(
     queue_incoming: str,
     queue_outgoing: str,
@@ -687,6 +709,7 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_520__preload_max_concurrent_tasks(
     queue_incoming: str,
     queue_outgoing: str,
@@ -736,6 +759,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_530__preload_max_concurrent_tasks_exceptions(
     queue_incoming: str,
     queue_outgoing: str,
@@ -902,6 +926,7 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 ########################################################################################
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2000_init(
     queue_incoming: str,
     queue_outgoing: str,
@@ -958,6 +983,7 @@ with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     )
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2001_init__timeout_error(
     queue_incoming: str,
     queue_outgoing: str,
@@ -996,6 +1022,7 @@ time.sleep({init_timeout})
         assert f.read().strip() == "hello world!"
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2002_init__exception(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1031,6 +1058,7 @@ raise ValueError('no good!')
         assert f.read().strip() == "hello world!"
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2010_init__use_in_task(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1091,6 +1119,7 @@ with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
 ########################################################################################
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_3000_external_directories(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1150,6 +1179,7 @@ assert open(file_two).read().strip() == 'beta'
 ########################################################################################
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_4000__no_output_ok(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1191,6 +1221,7 @@ async def test_4000__no_output_ok(
 ########################################################################################
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_5000__io_from_envvars(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1234,6 +1265,7 @@ print(output, file=open(os.environ['EWMS_TASK_OUTFILE'],'w'))" """,  # double ca
     ########################################################################################
 
 
+@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_6000__task_env_vars(
     queue_incoming: str,
     queue_outgoing: str,

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -8,9 +8,7 @@ import os
 import pickle
 import re
 import time
-import uuid
 from datetime import date, timedelta
-from pathlib import Path
 from pprint import pprint
 from typing import List, Optional
 from unittest.mock import patch
@@ -30,16 +28,6 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 TIMEOUT_INCOMING = 3
 
 MSGS_TO_SUBPROC = ["item" + str(i) for i in range(30)]
-
-
-@pytest.fixture
-def unique_pwd() -> None:
-    """Create unique directory and cd to it.
-    Enables tests to be ran in parallel without file conflicts.
-    """
-    root = Path(uuid.uuid4().hex)
-    root.mkdir()
-    os.chdir(root)
 
 
 @pytest.fixture
@@ -174,7 +162,6 @@ TEST_1000_SLEEP = 150.0  # anything lower doesn't upset rabbitmq enough
         TEST_1000_SLEEP / 10,  # will have no hb issues
     ],
 )
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_1000__heartbeat_workaround__rabbitmq_only(
     queue_incoming: str,
     queue_outgoing: str,
@@ -212,7 +199,6 @@ async def test_1000__heartbeat_workaround__rabbitmq_only(
         ),
     ],
 )
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_000(
     image_envvar: str,
     queue_incoming: str,
@@ -254,7 +240,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_001__txt__str_filetype(
     queue_incoming: str,
     queue_outgoing: str,
@@ -297,7 +282,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_100__json__objects(
     queue_incoming: str,
     queue_outgoing: str,
@@ -345,7 +329,6 @@ json.dump(output, open('{{OUTFILE}}','w'))" """,
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_101__json__preserialized(
     queue_incoming: str,
     queue_outgoing: str,
@@ -393,7 +376,6 @@ json.dump(output, open('{{OUTFILE}}','w'))" """,
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_200__pkl_b64(
     queue_incoming: str,
     queue_outgoing: str,
@@ -458,7 +440,6 @@ print(outdata, file=open('{{OUTFILE}}','w'), end='')" """,
 
 
 @pytest.mark.parametrize("quarantine", [None, 20])
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_400__exception_quarantine(
     queue_incoming: str,
     queue_outgoing: str,
@@ -510,7 +491,6 @@ async def test_400__exception_quarantine(
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_420__timeout(
     queue_incoming: str,
     queue_outgoing: str,
@@ -577,7 +557,6 @@ PREFETCH_TEST_PARAMETERS = sorted(
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_500__concurrent_load_max_concurrent_tasks(
     queue_incoming: str,
     queue_outgoing: str,
@@ -635,7 +614,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
     condition=config.ENV.EWMS_PILOT_QUEUE_INCOMING_BROKER_TYPE == "rabbitmq",
 )
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_510__concurrent_load_max_concurrent_tasks_exceptions(
     queue_incoming: str,
     queue_outgoing: str,
@@ -709,7 +687,6 @@ raise ValueError('gotta fail: ' + output.strip())" """,  # double cat
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_520__preload_max_concurrent_tasks(
     queue_incoming: str,
     queue_outgoing: str,
@@ -759,7 +736,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 
 
 @pytest.mark.parametrize("prefetch", PREFETCH_TEST_PARAMETERS)
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_530__preload_max_concurrent_tasks_exceptions(
     queue_incoming: str,
     queue_outgoing: str,
@@ -926,7 +902,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 ########################################################################################
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2000_init(
     queue_incoming: str,
     queue_outgoing: str,
@@ -983,7 +958,6 @@ with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     )
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2001_init__timeout_error(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1022,7 +996,6 @@ time.sleep({init_timeout})
         assert f.read().strip() == "hello world!"
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2002_init__exception(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1058,7 +1031,6 @@ raise ValueError('no good!')
         assert f.read().strip() == "hello world!"
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_2010_init__use_in_task(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1119,7 +1091,6 @@ with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
 ########################################################################################
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_3000_external_directories(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1179,7 +1150,6 @@ assert open(file_two).read().strip() == 'beta'
 ########################################################################################
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_4000__no_output_ok(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1221,7 +1191,6 @@ async def test_4000__no_output_ok(
 ########################################################################################
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_5000__io_from_envvars(
     queue_incoming: str,
     queue_outgoing: str,
@@ -1265,7 +1234,6 @@ print(output, file=open(os.environ['EWMS_TASK_OUTFILE'],'w'))" """,  # double ca
     ########################################################################################
 
 
-@pytest.mark.usefixtures("unique_pwd")  # needed specifically for nats on docker
 async def test_6000__task_env_vars(
     queue_incoming: str,
     queue_outgoing: str,


### PR DESCRIPTION
~Fixes a strange test failure seen for NATS within a docker container when the outgoing queue is empty (and no messages will ever be returned).~

**Update:** This bug was due to a forgotten ack after tasks that don't produce an output event (#95). For some reason (probably due to a change in timing), these specific test cases exposed this error even though #95 passed 100%.