### PR TITLE
Add `{{DATA_HUB}}` Container Arg Placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To transfer files between task containers, a shared directory is available to al
 
 The pilot provides the filepath to the "data hub" in two ways:
 
-1. By replacing the placeholder string, `{{DATAHUB}}`, in the container's arguments at runtime.
+1. By replacing the placeholder string, `{{DATA_HUB}}`, in the container's arguments at runtime.
 2. By setting the task container's environment variable: `EWMS_TASK_DATA_HUB_DIR`.
 
 **Note**:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An **input event** is provided to the task container as a file. The task contain
 The pilot provides the filepaths to the input and output files in two ways:
 
 1. By replacing the placeholder strings, `{{INFILE}}` and `{{OUTFILE}}`, in the container's arguments at runtime.
-2. By setting the task container's environment variables `EWMS_TASK_INFILE` and `EWMS_TASK_OUTFILE`.
+2. By setting the task container's environment variables: `EWMS_TASK_INFILE` and `EWMS_TASK_OUTFILE`.
 
 The files' extensions are configured by the pilot's environment variables, `EWMS_PILOT_INFILE_EXT` and `EWMS_PILOT_OUTFILE_EXT`: by default, these are `.in` and `.out`, respectively.
 
@@ -46,7 +46,12 @@ Task containers (and [init containers](#the-init-container)) can interact with e
 
 #### Inter-Task Files
 
-To transfer files between task containers, a shared directory is available to all task containers. This is provided by the environment variable `EWMS_TASK_DATA_HUB_DIR`, referred to as the "data hub".
+To transfer files between task containers, a shared directory is available to all task containers and the init container.
+
+The pilot provides the filepath to the "data hub" in two ways:
+
+1. By replacing the placeholder string, `{{DATAHUB}}`, in the container's arguments at runtime.
+2. By setting the task container's environment variable: `EWMS_TASK_DATA_HUB_DIR`.
 
 **Note**:
 

--- a/ewms_pilot/init_container/init_container.py
+++ b/ewms_pilot/init_container/init_container.py
@@ -21,7 +21,6 @@ async def run_init_container(
     await housekeeper.running_init_container()
 
     dirs = DirectoryCatalog(f"init-{uuid.uuid4().hex}")
-    dirs.outputs_on_pilot.mkdir(parents=True, exist_ok=False)
 
     task = asyncio.create_task(
         init_runner.run_container(

--- a/ewms_pilot/init_container/init_container.py
+++ b/ewms_pilot/init_container/init_container.py
@@ -31,6 +31,7 @@ async def run_init_container(
             {
                 InTaskContainerEnvVarNames.EWMS_TASK_DATA_HUB_DIR.name: dirs.pilot_data_hub.in_task_container,
             },
+            datahub_arg_placeholder_replacement=dirs.pilot_data_hub.in_task_container,
         )
     )
     pending = set([task])

--- a/ewms_pilot/init_container/init_container.py
+++ b/ewms_pilot/init_container/init_container.py
@@ -31,7 +31,7 @@ async def run_init_container(
             {
                 InTaskContainerEnvVarNames.EWMS_TASK_DATA_HUB_DIR.name: dirs.pilot_data_hub.in_task_container,
             },
-            datahub_arg_placeholder_replacement=dirs.pilot_data_hub.in_task_container,
+            datahub_arg_replacement=dirs.pilot_data_hub.in_task_container,
         )
     )
     pending = set([task])

--- a/ewms_pilot/init_container/init_container.py
+++ b/ewms_pilot/init_container/init_container.py
@@ -31,7 +31,7 @@ async def run_init_container(
             {
                 InTaskContainerEnvVarNames.EWMS_TASK_DATA_HUB_DIR.name: dirs.pilot_data_hub.in_task_container,
             },
-            datahub_arg_replacement=dirs.pilot_data_hub.in_task_container,
+            datahub_arg_replacement=str(dirs.pilot_data_hub.in_task_container),
         )
     )
     pending = set([task])

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -52,8 +52,9 @@ async def process_msg_task(
             InTaskContainerEnvVarNames.EWMS_TASK_INFILE.name: in_container_infile,
             InTaskContainerEnvVarNames.EWMS_TASK_OUTFILE.name: in_container_outfile,
         },
-        infile_arg_replacement=in_container_infile,
-        outfile_arg_replacement=in_container_outfile,
+        infile_arg_placeholder_replacement=in_container_infile,
+        outfile_arg_placeholder_replacement=in_container_outfile,
+        datahub_arg_placeholder_replacement=dirs.pilot_data_hub.in_task_container,
     )
 
     # get outfile response

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -54,7 +54,7 @@ async def process_msg_task(
         },
         infile_arg_replacement=in_container_infile,
         outfile_arg_replacement=in_container_outfile,
-        datahub_arg_replacement=dirs.pilot_data_hub.in_task_container,
+        datahub_arg_replacement=str(dirs.pilot_data_hub.in_task_container),
     )
 
     # get outfile response

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -32,7 +32,6 @@ async def process_msg_task(
 
     # staging-dir logic -- includes stderr/stdout files (see below)
     dirs = DirectoryCatalog(str(in_msg.uuid))
-    dirs.outputs_on_pilot.mkdir(parents=True, exist_ok=False)
     dirs.task_io.on_pilot.mkdir(parents=True, exist_ok=False)
 
     # create in/out file *names* -- piggy-back the uuid since it's unique and trackable

--- a/ewms_pilot/tasks/task.py
+++ b/ewms_pilot/tasks/task.py
@@ -52,9 +52,9 @@ async def process_msg_task(
             InTaskContainerEnvVarNames.EWMS_TASK_INFILE.name: in_container_infile,
             InTaskContainerEnvVarNames.EWMS_TASK_OUTFILE.name: in_container_outfile,
         },
-        infile_arg_placeholder_replacement=in_container_infile,
-        outfile_arg_placeholder_replacement=in_container_outfile,
-        datahub_arg_placeholder_replacement=dirs.pilot_data_hub.in_task_container,
+        infile_arg_replacement=in_container_infile,
+        outfile_arg_replacement=in_container_outfile,
+        datahub_arg_replacement=dirs.pilot_data_hub.in_task_container,
     )
 
     # get outfile response

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -222,18 +222,27 @@ class ContainerRunner:
         stderrfile: Path,
         mount_bindings: str,
         env_as_dict: dict,
-        infile_arg_replacement: str = "",
-        outfile_arg_replacement: str = "",
+        infile_arg_placeholder_replacement: str = "",
+        outfile_arg_placeholder_replacement: str = "",
+        datahub_arg_placeholder_replacement: str = "",
     ) -> None:
         """Run the container and dump outputs."""
         dump_output = ENV.EWMS_PILOT_DUMP_TASK_OUTPUT
 
-        # insert in/out files *paths* into task_args
+        # insert arg placeholder replacments
         inst_args = self.args
-        if infile_arg_replacement:
-            inst_args = inst_args.replace("{{INFILE}}", infile_arg_replacement)
-        if outfile_arg_replacement:
-            inst_args = inst_args.replace("{{OUTFILE}}", outfile_arg_replacement)
+        if infile_arg_placeholder_replacement:
+            inst_args = inst_args.replace(
+                "{{INFILE}}", infile_arg_placeholder_replacement
+            )
+        if outfile_arg_placeholder_replacement:
+            inst_args = inst_args.replace(
+                "{{OUTFILE}}", outfile_arg_placeholder_replacement
+            )
+        if datahub_arg_placeholder_replacement:
+            inst_args = inst_args.replace(
+                "{{DATAHUB}}", datahub_arg_placeholder_replacement
+            )
 
         # assemble env strings
         env_options = " ".join(

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -240,7 +240,7 @@ class ContainerRunner:
             for token in ["{{OUTFILE}}", "{{OUT_FILE}}"]:
                 inst_args = inst_args.replace(token, outfile_arg_replacement)
         if datahub_arg_replacement:
-            for token in ["{{DATAHUB}}", "{{DATA_HUB}}"]:
+            for token in ["{{DATA_HUB}}", "{{DATAHUB}}"]:
                 inst_args = inst_args.replace(token, datahub_arg_replacement)
 
         # assemble env strings

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -50,7 +50,7 @@ class DirectoryCatalog:
         in_task_container: Path
 
     def __init__(self, name: str):
-        """Directories are not pre-created; you must `mkdir -p` to use."""
+        """All directories except the task-io dir is pre-created (mkdir)."""
         self._namebased_dir = PILOT_DATA_DIR / name
 
         # for inter-task/init storage: startup data, init container's output, etc.
@@ -58,9 +58,11 @@ class DirectoryCatalog:
             PILOT_DATA_DIR / PILOT_DATA_HUB_DIR_NAME,
             Path(f"/{PILOT_DATA_DIR.name}/{PILOT_DATA_HUB_DIR_NAME}"),
         )
+        self.pilot_data_hub.on_pilot.mkdir(parents=True, exist_ok=True)
 
         # for persisting stderr and stdout
         self.outputs_on_pilot = self._namebased_dir / "outputs"
+        self.outputs_on_pilot.mkdir(parents=True, exist_ok=False)
 
         # for message-based task i/o
         self.task_io = self._ContainerBindMountDirPair(

--- a/ewms_pilot/utils/runner.py
+++ b/ewms_pilot/utils/runner.py
@@ -222,27 +222,26 @@ class ContainerRunner:
         stderrfile: Path,
         mount_bindings: str,
         env_as_dict: dict,
-        infile_arg_placeholder_replacement: str = "",
-        outfile_arg_placeholder_replacement: str = "",
-        datahub_arg_placeholder_replacement: str = "",
+        infile_arg_replacement: str = "",
+        outfile_arg_replacement: str = "",
+        datahub_arg_replacement: str = "",
     ) -> None:
         """Run the container and dump outputs."""
         dump_output = ENV.EWMS_PILOT_DUMP_TASK_OUTPUT
 
-        # insert arg placeholder replacments
+        # insert arg placeholder replacements
+        # -> give an alternative for each token replacement b/c it'd be a shame if
+        #    things broke this late in the game
         inst_args = self.args
-        if infile_arg_placeholder_replacement:
-            inst_args = inst_args.replace(
-                "{{INFILE}}", infile_arg_placeholder_replacement
-            )
-        if outfile_arg_placeholder_replacement:
-            inst_args = inst_args.replace(
-                "{{OUTFILE}}", outfile_arg_placeholder_replacement
-            )
-        if datahub_arg_placeholder_replacement:
-            inst_args = inst_args.replace(
-                "{{DATAHUB}}", datahub_arg_placeholder_replacement
-            )
+        if infile_arg_replacement:
+            for token in ["{{INFILE}}", "{{IN_FILE}}"]:
+                inst_args = inst_args.replace(token, infile_arg_replacement)
+        if outfile_arg_replacement:
+            for token in ["{{OUTFILE}}", "{{OUT_FILE}}"]:
+                inst_args = inst_args.replace(token, outfile_arg_replacement)
+        if datahub_arg_replacement:
+            for token in ["{{DATAHUB}}", "{{DATA_HUB}}"]:
+                inst_args = inst_args.replace(token, datahub_arg_replacement)
 
         # assemble env strings
         env_options = " ".join(

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -926,7 +926,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
             init_args="""python3 -c "
 import os
-os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
@@ -979,7 +978,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_args=f"""python3 -c "
 import time
 import os
-os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
@@ -1015,7 +1013,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
             init_args="""python3 -c "
 import os
-os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     print('writing hello world to a file...')
     print('hello world!', file=f)
@@ -1056,7 +1053,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
             init_args="""python3 -c "
 import os
-os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
     print('writing to a file...')
     print('blue', file=f)
@@ -1111,8 +1107,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             #
             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
             init_args="""python3 -c "
-import os
-os.makedirs('{{DATA_HUB}}', exist_ok=True)
 with open('{{DATA_HUB}}' + '/initoutput', 'w') as f:
     print('writing to a file...')
     print('blue', file=f)
@@ -1326,7 +1320,6 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
             init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
             init_args="""python3 -c "
 import os
-os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 assert os.environ['INIT_FOO'] == 'BOT'
 assert os.environ['INIT_BAZ'] == '99'
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -1031,11 +1031,11 @@ raise ValueError('no good!')
         assert f.read().strip() == "hello world!"
 
 
-async def test_2010_init__use_in_task(
+async def test_2100_use_data_hub_in_init_and_tasks__env_var(
     queue_incoming: str,
     queue_outgoing: str,
 ) -> None:
-    """Test a normal init container's outfile in another task."""
+    """Test a normal init container's data hub file in another task."""
     msgs_to_subproc = MSGS_TO_SUBPROC
     msgs_outgoing_expected = [f"{x}blue\n" for x in msgs_to_subproc]
 
@@ -1058,6 +1058,62 @@ print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
 import os
 os.makedirs(os.environ['EWMS_TASK_DATA_HUB_DIR'], exist_ok=True)
 with open(os.environ['EWMS_TASK_DATA_HUB_DIR'] + '/initoutput', 'w') as f:
+    print('writing to a file...')
+    print('blue', file=f)
+" """,
+            queue_incoming=queue_incoming,
+            queue_outgoing=queue_outgoing,
+            timeout_incoming=TIMEOUT_INCOMING,
+        ),
+    )
+
+    # check init's output
+    with open(PILOT_DATA_DIR / PILOT_DATA_HUB_DIR_NAME / "initoutput") as f:
+        assert f.read().strip() == "blue"
+
+    # check task stuff
+    await assert_results(queue_outgoing, msgs_outgoing_expected)
+    assert_pilot_dirs(
+        len(msgs_outgoing_expected),
+        [
+            "task-io/infile-{UUID}.in",
+            "task-io/outfile-{UUID}.out",
+            "task-io/",
+            "outputs/stderrfile",
+            "outputs/stdoutfile",
+            "outputs/",
+        ],
+        ["initoutput"],
+        has_init_cmd_subdir=True,
+    )
+
+
+async def test_2110_use_data_hub_in_init_and_tasks__arg_placeholder(
+    queue_incoming: str,
+    queue_outgoing: str,
+) -> None:
+    """Test a normal init container's data hub file in another task."""
+    msgs_to_subproc = MSGS_TO_SUBPROC
+    msgs_outgoing_expected = [f"{x}blue\n" for x in msgs_to_subproc]
+
+    # run producer & consumer concurrently
+    await asyncio.gather(
+        populate_queue(
+            queue_incoming,
+            msgs_to_subproc,
+            intermittent_sleep=TIMEOUT_INCOMING / 4,
+        ),
+        consume_and_reply(
+            f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
+            """python3 -c "
+output = open('{{INFILE}}').read().strip() + open('{{DATA_HUB}}' + '/initoutput').read().strip();
+print(output, file=open('{{OUTFILE}}','w'))" """,  # double cat
+            #
+            init_image=f"{os.environ['CI_TEST_ALPINE_PYTHON_IMAGE']}",
+            init_args="""python3 -c "
+import os
+os.makedirs('{{DATA_HUB}}', exist_ok=True)
+with open('{{DATA_HUB}}' + '/initoutput', 'w') as f:
     print('writing to a file...')
     print('blue', file=f)
 " """,


### PR DESCRIPTION
Also, the data hub and outputs directories will be auto-created (mkdir). This makes integration testing the pilot via the pypi package much more streamlined (see https://github.com/icecube/skymap_scanner/pull/273)